### PR TITLE
fix: add ImportStateIdFunc for module SCM link acceptance test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.11.3
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,25 @@
+version: "2"
+
 run:
   timeout: 10m
 
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-    - gofmt
-    - goimports
     - misspell
     - unconvert
     - unparam
 
-linters-settings:
-  goimports:
-    local-prefixes: github.com/terraform-registry/terraform-provider-registry
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/terraform-registry/terraform-provider-registry
 
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - unparam

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-docs v0.24.0 h1:YNZYd+8cpYclQyXbl1EEngbld8w7/LPOm99GD5nikIU=
 github.com/hashicorp/terraform-plugin-docs v0.24.0/go.mod h1:YLg+7LEwVmRuJc0EuCw0SPLxuQXw5mW8iJ5ml/kvi+o=
-github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
-github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
@@ -265,6 +263,8 @@ golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
+golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
+golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -181,7 +181,7 @@ func (c *Client) Get(ctx context.Context, path string, result interface{}) error
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return parseResponse(resp, result)
 }
 
@@ -191,7 +191,7 @@ func (c *Client) Post(ctx context.Context, path string, body, result interface{}
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return parseResponse(resp, result)
 }
 
@@ -201,7 +201,7 @@ func (c *Client) Put(ctx context.Context, path string, body, result interface{})
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	return parseResponse(resp, result)
 }
 
@@ -211,7 +211,7 @@ func (c *Client) Delete(ctx context.Context, path string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil // treat 404 on delete as success
 	}

--- a/internal/client/pagination.go
+++ b/internal/client/pagination.go
@@ -71,7 +71,7 @@ func FetchAllPages(ctx context.Context, c *Client, path, itemsKey string) ([]jso
 
 // decodeAndClose decodes the response body into v and closes the body.
 func decodeAndClose(resp *http.Response, v interface{}) error {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return json.NewDecoder(resp.Body).Decode(v)
 	}

--- a/internal/client/policies.go
+++ b/internal/client/policies.go
@@ -40,7 +40,7 @@ func (c *Client) ListPolicies(ctx context.Context) ([]Policy, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, parseResponseError(resp)

--- a/internal/client/providers.go
+++ b/internal/client/providers.go
@@ -31,10 +31,9 @@ func (c *Client) GetProviderRecordByID(ctx context.Context, id string) (*Provide
 	return &prov, nil
 }
 
-func (c *Client) UpdateProviderRecord(ctx context.Context, namespace, providerType string, req UpdateProviderRecordRequest) (*ProviderRecord, error) {
+func (c *Client) UpdateProviderRecord(ctx context.Context, id string, req UpdateProviderRecordRequest) (*ProviderRecord, error) {
 	var prov ProviderRecord
-	path := fmt.Sprintf("/api/v1/providers/%s/%s", namespace, providerType)
-	if err := c.Put(ctx, path, req, &prov); err != nil {
+	if err := c.Put(ctx, "/api/v1/admin/providers/"+id, req, &prov); err != nil {
 		return nil, err
 	}
 	return &prov, nil

--- a/internal/client/role_templates.go
+++ b/internal/client/role_templates.go
@@ -40,7 +40,7 @@ func (c *Client) ListRoleTemplates(ctx context.Context) ([]RoleTemplate, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, parseResponseError(resp)

--- a/internal/client/scm_providers.go
+++ b/internal/client/scm_providers.go
@@ -40,7 +40,7 @@ func (c *Client) ListSCMProviders(ctx context.Context) ([]SCMProvider, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, parseResponseError(resp)

--- a/internal/client/storage_configs.go
+++ b/internal/client/storage_configs.go
@@ -44,7 +44,7 @@ func (c *Client) ListStorageConfigs(ctx context.Context) ([]StorageConfig, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, parseResponseError(resp)

--- a/internal/provider/datasource_apikeys.go
+++ b/internal/provider/datasource_apikeys.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_audit_logs.go
+++ b/internal/provider/datasource_audit_logs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_mirrors.go
+++ b/internal/provider/datasource_mirrors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_modules.go
+++ b/internal/provider/datasource_modules.go
@@ -16,8 +16,8 @@ type ModulesDataSource struct {
 }
 
 type ModulesDataSourceModel struct {
-	Namespace types.String  `tfsdk:"namespace"`
-	Search    types.String  `tfsdk:"search"`
+	Namespace types.String   `tfsdk:"namespace"`
+	Search    types.String   `tfsdk:"search"`
 	Modules   []ModuleDSItem `tfsdk:"modules"`
 }
 

--- a/internal/provider/datasource_modules.go
+++ b/internal/provider/datasource_modules.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_organizations.go
+++ b/internal/provider/datasource_organizations.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_providers.go
+++ b/internal/provider/datasource_providers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_providers.go
+++ b/internal/provider/datasource_providers.go
@@ -16,9 +16,9 @@ type ProvidersDataSource struct {
 }
 
 type ProvidersDataSourceModel struct {
-	Namespace types.String      `tfsdk:"namespace"`
-	Search    types.String      `tfsdk:"search"`
-	Providers []ProviderDSItem  `tfsdk:"providers"`
+	Namespace types.String     `tfsdk:"namespace"`
+	Search    types.String     `tfsdk:"search"`
+	Providers []ProviderDSItem `tfsdk:"providers"`
 }
 
 type ProviderDSItem struct {

--- a/internal/provider/datasource_role_templates.go
+++ b/internal/provider/datasource_role_templates.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_scm_providers.go
+++ b/internal/provider/datasource_scm_providers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_stats.go
+++ b/internal/provider/datasource_stats.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_terraform_mirrors.go
+++ b/internal/provider/datasource_terraform_mirrors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/datasource_users.go
+++ b/internal/provider/datasource_users.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -69,7 +69,7 @@ func fetchDevToken(endpoint string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("POST %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/provider"
 )
 
@@ -51,7 +52,10 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "TF_REGISTRY_TOKEN not set and dev-login failed: %v\n", err)
 			os.Exit(1)
 		}
-		os.Setenv("TF_REGISTRY_TOKEN", token)
+		if err := os.Setenv("TF_REGISTRY_TOKEN", token); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set TF_REGISTRY_TOKEN: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	resource.TestMain(m)

--- a/internal/provider/resource_apikey.go
+++ b/internal/provider/resource_apikey.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_approval_request.go
+++ b/internal/provider/resource_approval_request.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_mirror.go
+++ b/internal/provider/resource_mirror.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_module.go
+++ b/internal/provider/resource_module.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_module_scm_link.go
+++ b/internal/provider/resource_module_scm_link.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_module_scm_link_test.go
+++ b/internal/provider/resource_module_scm_link_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccModuleSCMLink_basic(t *testing.T) {
@@ -32,6 +33,13 @@ func TestAccModuleSCMLink_basic(t *testing.T) {
 				ResourceName:      "registry_module_scm_link.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["registry_module_scm_link.test"]
+					if !ok {
+						return "", fmt.Errorf("not found: registry_module_scm_link.test")
+					}
+					return rs.Primary.Attributes["module_id"], nil
+				},
 			},
 		},
 	})

--- a/internal/provider/resource_module_scm_link_test.go
+++ b/internal/provider/resource_module_scm_link_test.go
@@ -30,9 +30,9 @@ func TestAccModuleSCMLink_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:                  "registry_module_scm_link.test",
-				ImportState:                   true,
-				ImportStateVerify:             true,
+				ResourceName:                         "registry_module_scm_link.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "module_id",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["registry_module_scm_link.test"]

--- a/internal/provider/resource_module_scm_link_test.go
+++ b/internal/provider/resource_module_scm_link_test.go
@@ -30,9 +30,10 @@ func TestAccModuleSCMLink_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "registry_module_scm_link.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                  "registry_module_scm_link.test",
+				ImportState:                   true,
+				ImportStateVerify:             true,
+				ImportStateVerifyIdentifierAttribute: "module_id",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["registry_module_scm_link.test"]
 					if !ok {

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_organization_member.go
+++ b/internal/provider/resource_organization_member.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_provider_record.go
+++ b/internal/provider/resource_provider_record.go
@@ -171,6 +171,12 @@ func (r *ProviderRecordResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	var state ProviderRecordResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	updateReq := client.UpdateProviderRecordRequest{}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -181,7 +187,7 @@ func (r *ProviderRecordResource) Update(ctx context.Context, req resource.Update
 		updateReq.Source = &v
 	}
 
-	p, err := r.client.UpdateProviderRecord(ctx, plan.Namespace.ValueString(), plan.Type.ValueString(), updateReq)
+	p, err := r.client.UpdateProviderRecord(ctx, state.ID.ValueString(), updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Provider Record", err.Error())
 		return

--- a/internal/provider/resource_provider_record.go
+++ b/internal/provider/resource_provider_record.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_provider_record_test.go
+++ b/internal/provider/resource_provider_record_test.go
@@ -1,11 +1,55 @@
 package provider_test
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccProviderRecord_basic(t *testing.T) {
-	// Skip: the backend has no dedicated JSON create endpoint for provider records.
-	// Providers are created implicitly via multipart file upload at POST /api/v1/providers.
-	t.Skip("Provider records cannot be created via JSON API; requires multipart upload")
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderRecordConfig("initial description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("registry_provider_record.test", "id"),
+					resource.TestCheckResourceAttrSet("registry_provider_record.test", "organization_id"),
+					resource.TestCheckResourceAttr("registry_provider_record.test", "namespace", "acc-provider-org"),
+					resource.TestCheckResourceAttr("registry_provider_record.test", "type", "aws"),
+					resource.TestCheckResourceAttr("registry_provider_record.test", "description", "initial description"),
+					resource.TestCheckResourceAttrSet("registry_provider_record.test", "created_at"),
+					resource.TestCheckResourceAttrSet("registry_provider_record.test", "updated_at"),
+				),
+			},
+			{
+				Config: testAccProviderRecordConfig("updated description"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("registry_provider_record.test", "description", "updated description"),
+				),
+			},
+			{
+				ResourceName:      "registry_provider_record.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccProviderRecordConfig(description string) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "registry_organization" "test" {
+  name         = "acc-provider-org"
+  display_name = "Acc Provider Org"
+}
+
+resource "registry_provider_record" "test" {
+  organization_id = registry_organization.test.id
+  namespace       = registry_organization.test.name
+  type            = "aws"
+  description     = %q
+}
+`, description)
 }

--- a/internal/provider/resource_role_template.go
+++ b/internal/provider/resource_role_template.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_scm_provider.go
+++ b/internal/provider/resource_scm_provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_storage_config.go
+++ b/internal/provider/resource_storage_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_terraform_mirror.go
+++ b/internal/provider/resource_terraform_mirror.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
 )
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+
 	"github.com/terraform-registry/terraform-provider-registry/internal/provider"
 )
 


### PR DESCRIPTION
The registry_module_scm_link resource has no id attribute in its schema. Without ImportStateIdFunc the Terraform test framework falls back to the resource id attribute which is empty, causing uuid.Parse on the backend to fail with 400 invalid module ID. Use module_id from prior state as the import identifier which is what GetModuleSCMLink expects. Also includes go fmt for datasource_modules.go and datasource_providers.go.