### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, development]
   push:
-    branches: [main]
+    branches: [main, development]
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,228 @@
+# CLAUDE.md — Terraform Provider for Private Terraform Registry
+
+## Development Workflow
+
+All changes follow this workflow. Do not deviate from it.
+
+### Branches
+
+- `main` — production-ready, tagged releases only. **Must always exist — never delete.**
+- `development` — integration branch; all feature/fix branches merge here first. **Must always exist — never delete.**
+- Feature/fix branches are created from `development`, never from `main`. Delete them from remote after their PR is merged; clean up locally with `git branch -d`.
+
+```bash
+# After a feature/fix PR is merged:
+git push origin --delete fix/short-description   # remove remote branch
+git branch -d fix/short-description              # remove local branch
+git remote prune origin                          # prune stale remote-tracking refs
+```
+
+### Step-by-step
+
+1. **Open a GitHub issue** describing the bug or feature before writing any code.
+
+2. **Create a branch from `development`**:
+
+   ```bash
+   git fetch origin
+   git checkout -b fix/short-description origin/development
+   # or: feature/short-description
+   ```
+
+3. **Implement the change.**
+
+4. **Before committing — run the full local quality gate** (CI will reject anything that fails these):
+
+   ```bash
+   # Build
+   go build ./...
+
+   # Format & vet
+   go fmt ./...
+   go vet ./...
+
+   # Lint (requires golangci-lint v2)
+   golangci-lint run
+
+   # Unit tests
+   go test -v -count=1 ./internal/client/...
+
+   # Acceptance tests (requires running backend — see README)
+   TF_ACC=1 TF_REGISTRY_ENDPOINT=http://localhost:8081 go test -v ./internal/provider/...
+   ```
+
+   Do not push until all of the above pass locally.
+
+5. **Commit — no co-author attribution**:
+
+   ```bash
+   git add <specific files>
+   git commit -m "fix: short description of what was fixed
+
+   Closes #<issue-number>"
+   ```
+
+6. **Rebase onto `development` before pushing** to minimise merge conflicts with sibling branches:
+
+   ```bash
+   git fetch origin
+   git rebase origin/development
+   ```
+
+7. **Push to origin**:
+
+   ```bash
+   git push -u origin fix/short-description
+   ```
+
+8. **Open a PR from the feature branch → `development`**:
+
+   Include a `## Changelog` section in the PR body with the entry that should appear in `CHANGELOG.md` for this change. **Do not edit `CHANGELOG.md` in the branch** — changelog entries are collected from merged PR bodies at release time.
+
+   ```bash
+   gh pr create --base development --title "fix: short description" --body "$(cat <<'EOF'
+   Closes #<issue>
+
+   ## Changelog
+   - fix: short description of what was fixed
+   EOF
+   )"
+   ```
+
+   - Squash-merge into `development` when approved.
+
+9. **Open a PR from `development` → `main`** when the integration branch is ready to ship:
+
+   ```bash
+   gh pr create --base main --title "chore: release vX.Y.Z" --body "..."
+   ```
+
+### Parallel agents — coordination rules
+
+When multiple agents run concurrently, follow these rules to avoid conflicts:
+
+- **Never assign two agents to work on the same files at the same time.** If their scopes overlap, serialise them.
+- **Do not edit `CHANGELOG.md` in any branch.** Changelog entries live in PR bodies only (see step 8 above). This eliminates the most common parallel-agent conflict.
+- **Each agent rebases on `origin/development` immediately before pushing** (step 6 above). After any sibling PR is merged, remaining open branches must rebase again before their own merge.
+
+### Releasing a version
+
+When a release is called for:
+
+1. Collect the `## Changelog` sections from all PR bodies merged since the last release.
+
+2. Update `CHANGELOG.md` on `development` — promote `[Unreleased]` to the new version with today's date and paste the collected entries:
+
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+   ### Fixed
+   - fix: ...
+   ### Added
+   - feat: ...
+   ```
+
+3. Commit directly on `development` and push (**no tag yet**):
+
+   ```bash
+   git commit -m "chore: release vX.Y.Z"
+   git push origin development
+   ```
+
+4. Merge `development` → `main` via PR.
+
+5. **After the PR is merged**, tag the commit that landed on `main` and push the tag:
+
+   ```bash
+   git fetch origin
+   git tag vX.Y.Z origin/main
+   git push origin vX.Y.Z
+   ```
+
+   > **Why tag after the merge?** The release PR produces a new merge commit SHA on `main`.
+   > Tagging on `development` before the merge leaves the tag pointing at the wrong commit —
+   > it will never appear in `main`'s history as a tagged release.
+
+6. **Verify the release workflow** fired within ~60 seconds:
+
+   ```bash
+   gh run list --workflow=release.yml --limit=3
+   ```
+
+   The workflow builds multi-platform provider binaries, creates a GitHub Release, and (if configured) publishes to the Terraform Registry.
+
+---
+
+## Project Overview
+
+A Terraform provider for managing all resources in a self-hosted
+[Terraform Registry Backend](https://github.com/sethbacon/terraform-registry-backend):
+users, organizations, modules, providers, mirrors, SCM integrations, storage backends, policies, and more.
+
+---
+
+## Repository Structure
+
+```txt
+terraform-provider-registry/
+├── internal/
+│   ├── client/       # HTTP client for the registry backend API
+│   └── provider/     # Terraform resource and data source implementations
+├── deployments/
+│   ├── docker-compose.test.yml   # Test stack (backend + postgres)
+│   └── seed-dev-admin.sql        # Dev admin user seed
+├── .github/workflows/
+│   ├── test.yml      # CI: build, lint, unit tests, acceptance tests
+│   └── release.yml   # GoReleaser: triggered by vX.Y.Z tag push
+├── .golangci.yml     # golangci-lint v2 configuration
+├── go.mod / go.sum
+├── main.go
+└── CHANGELOG.md
+```
+
+---
+
+## Common Commands
+
+```bash
+# Build
+go build ./...
+
+# Unit tests (no backend required)
+go test -v -count=1 ./internal/client/...
+
+# Acceptance tests (requires backend — see README)
+docker compose -f deployments/docker-compose.test.yml up -d
+TF_ACC=1 TF_REGISTRY_ENDPOINT=http://localhost:8081 go test -v ./internal/provider/...
+
+# Lint
+golangci-lint run
+
+# Install locally
+make install
+
+# Generate documentation
+make docs
+```
+
+---
+
+## Tech Stack
+
+| Concern       | Technology                                         |
+| ------------- | -------------------------------------------------- |
+| Language      | Go 1.25+                                           |
+| Framework     | terraform-plugin-framework (hashicorp)             |
+| HTTP client   | net/http with retry + backoff                      |
+| Lint          | golangci-lint v2 (.golangci.yml)                   |
+| Release       | GoReleaser (triggered by vX.Y.Z tag on `main`)     |
+| Docs          | terraform-plugin-docs                              |
+
+---
+
+## Development Notes
+
+- The provider is published as `sethbacon/registry` on the Terraform Registry.
+- Acceptance tests require a live backend; the `deployments/docker-compose.test.yml` stack provides one.
+- `DEV_MODE=true` on the backend enables `POST /api/v1/dev/login` for test token fetching.
+- If `TF_REGISTRY_TOKEN` is unset, `TestMain` in `provider_test.go` fetches a dev token automatically.
+- Do not edit `CHANGELOG.md` in feature branches — see releasing workflow above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,195 @@
+# Contributing
+
+Thank you for your interest in contributing to the Terraform Registry Provider!
+
+## Branching Model
+
+This project uses a two-branch strategy:
+
+- **`main`** — production-ready code only. Every commit on `main` corresponds to a tagged release.
+  Do not push directly to `main`.
+- **`development`** — the integration branch. All feature and fix branches are merged here first.
+  CI must pass before merging.
+
+Feature and fix branches are created from `development` and merged back into `development` via
+pull request. When the integration branch is stable and ready to ship, a release PR is opened
+from `development` → `main`.
+
+## Getting Started
+
+### Prerequisites
+
+- [Go](https://golang.org/doc/install) >= 1.25
+- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.x
+- [Docker](https://docs.docker.com/get-docker/) (for acceptance tests)
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0 (for local testing)
+
+### Setup
+
+```bash
+git clone https://github.com/sethbacon/terraform-provider-registry
+cd terraform-provider-registry
+go mod download
+```
+
+## Making a Change
+
+### 1. Open an issue
+
+Before writing code, open a GitHub issue describing the bug or feature. Reference this issue
+in your commits and PR body.
+
+### 2. Create a branch from `development`
+
+```bash
+git fetch origin
+git checkout -b fix/short-description origin/development
+# or: feature/short-description
+```
+
+Use a short, lowercase, hyphenated description. Prefix with `fix/` for bug fixes or
+`feature/` for new functionality.
+
+### 3. Implement and test
+
+Run the full quality gate locally before pushing:
+
+```bash
+# Build
+go build ./...
+
+# Format and vet
+go fmt ./...
+go vet ./...
+
+# Lint
+golangci-lint run
+
+# Unit tests (no backend required)
+go test -v -count=1 ./internal/client/...
+```
+
+For changes that affect provider behaviour, run the acceptance tests too:
+
+```bash
+# Start the test backend
+docker compose -f deployments/docker-compose.test.yml up -d
+
+# Seed the dev admin user (once per fresh database)
+docker compose -f deployments/docker-compose.test.yml exec -T postgres \
+  psql -U registry -d terraform_registry < deployments/seed-dev-admin.sql
+
+# Run acceptance tests
+TF_ACC=1 TF_REGISTRY_ENDPOINT=http://localhost:8081 go test -v ./internal/provider/...
+```
+
+Do not push until all checks pass locally.
+
+### 4. Commit
+
+Write clear, imperative commit messages. No co-author attribution lines.
+
+```bash
+git add <specific files>
+git commit -m "fix: short description
+
+Closes #<issue-number>"
+```
+
+### 5. Rebase before pushing
+
+```bash
+git fetch origin
+git rebase origin/development
+```
+
+### 6. Push and open a pull request
+
+```bash
+git push -u origin fix/short-description
+```
+
+Open a PR targeting **`development`** (not `main`). Include:
+
+- A description of the change and why it is needed.
+- A reference to the issue (`Closes #N`).
+- A `## Changelog` section with the entry for `CHANGELOG.md`:
+
+```markdown
+## Changelog
+- fix: short description of what was fixed
+```
+
+Do **not** edit `CHANGELOG.md` in your branch. Changelog entries are collected from merged PR
+bodies at release time.
+
+### 7. Review and merge
+
+- Ensure CI passes (Build, Lint, Unit Tests, Acceptance Tests).
+- Address review feedback.
+- A maintainer will squash-merge your PR into `development`.
+
+### 8. Clean up
+
+After your PR is merged:
+
+```bash
+git push origin --delete fix/short-description   # remove remote branch
+git branch -d fix/short-description              # remove local branch
+git remote prune origin                          # prune stale remote-tracking refs
+```
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`).
+- Keep golangci-lint (`golangci-lint run`) clean — no new warnings.
+- Separate third-party imports from internal imports with a blank line:
+
+  ```go
+  import (
+      "context"
+      "fmt"
+
+      "github.com/hashicorp/terraform-plugin-framework/resource"
+
+      "github.com/terraform-registry/terraform-provider-registry/internal/client"
+  )
+  ```
+
+- Wrap `defer resp.Body.Close()` to satisfy errcheck:
+
+  ```go
+  defer func() { _ = resp.Body.Close() }()
+  ```
+
+## Running the Full Test Suite
+
+Unit tests only:
+
+```bash
+make test
+```
+
+Acceptance tests (requires Docker):
+
+```bash
+make testacc
+```
+
+## Releasing
+
+Releases are managed by maintainers. If you believe a release is needed, open an issue or
+mention it in a PR discussion.
+
+The release process:
+
+1. Collect changelog entries from merged PR bodies since the last release.
+2. Update `CHANGELOG.md` on `development`.
+3. Open a PR from `development` → `main`.
+4. After the PR is merged, tag the commit on `main` with `vX.Y.Z`.
+5. The `release.yml` workflow runs GoReleaser automatically.
+
+## Questions
+
+Open a [GitHub issue](https://github.com/sethbacon/terraform-provider-registry/issues) for
+bug reports, feature requests, or questions.

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ make docs
 
 ## Contributing
 
-1. Fork the repository and create a feature branch from `main`.
-2. Make your changes — add tests for new behaviour.
-3. Run `make test` and `make testacc` and ensure all tests pass.
-4. Run `make lint` and fix any reported issues.
-5. Open a pull request against `main`.
+This project uses a `main` / `development` two-branch model. All changes go through
+`development` first; only release PRs merge to `main`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow: branching conventions,
+local quality gate, commit style, PR checklist, and the release process.
 
 ## License
 

--- a/internal/provider/resource_mirror_test.go
+++ b/internal/provider/resource_mirror_test.go
@@ -31,9 +31,10 @@ func TestAccMirror_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "registry_mirror.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "registry_mirror.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/internal/provider/resource_module_test.go
+++ b/internal/provider/resource_module_test.go
@@ -29,9 +29,10 @@ func TestAccModule_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "registry_module.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "registry_module.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/internal/provider/resource_provider_record_test.go
+++ b/internal/provider/resource_provider_record_test.go
@@ -30,9 +30,10 @@ func TestAccProviderRecord_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "registry_provider_record.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "registry_provider_record.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"updated_at"},
 			},
 		},
 	})

--- a/internal/provider/resource_scm_provider_test.go
+++ b/internal/provider/resource_scm_provider_test.go
@@ -31,7 +31,7 @@ func TestAccSCMProvider_basic(t *testing.T) {
 				ResourceName:            "registry_scm_provider.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"client_id", "client_secret"},
+				ImportStateVerifyIgnore: []string{"client_id", "client_secret", "updated_at"},
 			},
 		},
 	})


### PR DESCRIPTION
Initial release of the Terraform Registry provider.

Merges all provider work from `development` into `main` for tagging as v0.1.0.

## Changelog
See [CHANGELOG.md](CHANGELOG.md) for the full v0.1.0 entry.