### PR TITLE
ci: pin goreleaser to v2.14.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: v2.14.3
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin goreleaser action to v2.14.3 to match `.goreleaser.yml` `version: 2` config. The `latest` alias resolves to v1.26.2 which rejects v2 configs.