### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2026-03-21
 
-### Fixed
+### Changed
 
-- Replace em dash in `docs/index.md` description frontmatter so the provider description renders correctly on registry.terraform.io
+- Add `subcategory` frontmatter to provider docs index for registry.terraform.io categorisation
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 page_title: "Provider: Terraform Registry"
+subcategory: "Cloud Automation"
 description: |-
   The Terraform Registry provider enables management of a self-hosted Terraform Registry backend instance, including users, organizations, modules, providers, mirrors, SCM integrations, and more.
 ---

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,5 +1,6 @@
 ---
 page_title: "Provider: Terraform Registry"
+subcategory: "Cloud Automation"
 description: |-
   The Terraform Registry provider enables management of a self-hosted Terraform Registry backend instance, including users, organizations, modules, providers, mirrors, SCM integrations, and more.
 ---


### PR DESCRIPTION
Add subcategory frontmatter to provider docs index for registry.terraform.io categorisation.

## Changelog
- docs: add subcategory frontmatter to provider index for registry categorisation