### PR TITLE
fix(client): decode storage config active flag as is_active

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -334,7 +334,7 @@ type UpdateTerraformMirrorRequest struct {
 type StorageConfig struct {
 	ID          string `json:"id"`
 	BackendType string `json:"backend_type"`
-	Active      bool   `json:"active"`
+	IsActive    bool   `json:"is_active"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 	// Individual backend fields returned by API (credentials redacted)

--- a/internal/client/storage_configs_test.go
+++ b/internal/client/storage_configs_test.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStorageConfig_DecodesIsActive guards against the JSON-tag drift fixed
+// in #6: backend renamed "active" to "is_active" before the provider's first
+// release, leaving the resource showing perpetual diff on the active attribute.
+func TestStorageConfig_DecodesIsActive(t *testing.T) {
+	// Sample response shape taken from backend StorageConfigResponse
+	// (backend/internal/db/models/storage_config.go).
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"backend_type": "s3",
+		"is_active": true,
+		"s3_region": "us-east-1",
+		"s3_bucket": "example",
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var sc StorageConfig
+	if err := json.Unmarshal(body, &sc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !sc.IsActive {
+		t.Errorf("IsActive = false, want true (JSON tag must be is_active)")
+	}
+	if sc.BackendType != "s3" {
+		t.Errorf("BackendType = %q, want s3", sc.BackendType)
+	}
+}

--- a/internal/provider/resource_storage_config.go
+++ b/internal/provider/resource_storage_config.go
@@ -126,7 +126,7 @@ func (r *StorageConfigResource) Create(ctx context.Context, req resource.CreateR
 			resp.Diagnostics.AddError("Error Activating Storage Config", err.Error())
 			return
 		}
-		sc.Active = true
+		sc.IsActive = true
 	}
 
 	model := storageConfigToModel(ctx, sc, configMap)
@@ -181,12 +181,12 @@ func (r *StorageConfigResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	if plan.Activate.ValueBool() && !sc.Active {
+	if plan.Activate.ValueBool() && !sc.IsActive {
 		if err := r.client.ActivateStorageConfig(ctx, sc.ID); err != nil {
 			resp.Diagnostics.AddError("Error Activating Storage Config", err.Error())
 			return
 		}
-		sc.Active = true
+		sc.IsActive = true
 	}
 
 	model := storageConfigToModel(ctx, sc, configMap)
@@ -315,7 +315,7 @@ func storageConfigToModel(ctx context.Context, sc *client.StorageConfig, preserv
 		ID:        types.StringValue(sc.ID),
 		Backend:   types.StringValue(sc.BackendType),
 		Config:    cfgValue,
-		Active:    types.BoolValue(sc.Active),
+		Active:    types.BoolValue(sc.IsActive),
 		CreatedAt: types.StringValue(normalizeTimestamp(sc.CreatedAt)),
 		UpdatedAt: types.StringValue(normalizeTimestamp(sc.UpdatedAt)),
 	}


### PR DESCRIPTION
Closes #6

## Summary

Backend renamed the storage config response field from `active` to `is_active` before the provider's first release. The provider's `client.StorageConfig.Active` JSON tag was never updated, so every storage config has been read as `active=false` since v0.1.0 — `registry_storage_config` shows perpetual diff on the `active` attribute and re-invokes the activation endpoint on every apply.

This PR:
- Renames the Go field to `IsActive` (matches backend) with JSON tag `is_active`
- Updates the three references inside `resource_storage_config.go`
- Adds a client unit test that round-trips a sample backend response

The Terraform attribute is still named `active` — only the wire-level JSON tag changes — so this is not a breaking change for HCL.

## Changelog
- fix: storage config `active` field decoded as `is_active` to match backend response