### PR TITLE
fix(mirrors): omit unset optional fields from update PUT payloads

### DIFF
--- a/internal/client/mirrors_test.go
+++ b/internal/client/mirrors_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestUpdateMirrorRequest_OmitsUnsetFields guards against the silent zero-value
+// PUT bug fixed in #8: backend treats omitted fields as "leave unchanged" but
+// the previous Go struct used plain bool/int, so missing optionals shipped as
+// `enabled: false` and `sync_interval_hours: 0`.
+func TestUpdateMirrorRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateMirrorRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wire := string(body)
+
+	// Must contain only what was set.
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	// Must NOT contain unset optional scalars — the fix for #8 is that these
+	// get omitted entirely rather than shipped as zero values.
+	for _, k := range []string{
+		`"enabled"`,
+		`"sync_interval_hours"`,
+		`"upstream_registry_url"`,
+		`"organization_id"`,
+		`"description"`,
+		`"version_filter"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}
+
+// TestUpdateTerraformMirrorRequest_OmitsUnsetFields covers the same guarantee
+// for the Terraform/OpenTofu binary mirror update request.
+func TestUpdateTerraformMirrorRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateTerraformMirrorRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	for _, k := range []string{
+		`"enabled"`,
+		`"sync_interval_hours"`,
+		`"gpg_verify"`,
+		`"stable_only"`,
+		`"tool"`,
+		`"upstream_url"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}
+
+// TestCreateMirrorRequest_RequiredFieldsPresent confirms required scalars
+// (which are not pointers) still ship even when other fields are unset.
+func TestCreateMirrorRequest_RequiredFieldsPresent(t *testing.T) {
+	req := CreateMirrorRequest{
+		Name:                "test",
+		UpstreamRegistryURL: "https://registry.example.com",
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"test"`) {
+		t.Errorf("required name missing: %s", wire)
+	}
+	if !strings.Contains(wire, `"upstream_registry_url":"https://registry.example.com"`) {
+		t.Errorf("required upstream URL missing: %s", wire)
+	}
+	// Optional pointer scalars omitted.
+	if strings.Contains(wire, `"enabled"`) {
+		t.Errorf("unset enabled should be omitted: %s", wire)
+	}
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -255,6 +255,11 @@ type Mirror struct {
 }
 
 // CreateMirrorRequest is the payload for creating a mirror.
+//
+// Optional scalar fields use pointers so the wire payload omits them entirely
+// when the caller has nothing to set, matching the backend's
+// CreateMirrorConfigRequest semantics in
+// backend/internal/db/models/mirror.go.
 type CreateMirrorRequest struct {
 	Name                string   `json:"name"`
 	Description         *string  `json:"description,omitempty"`
@@ -264,22 +269,28 @@ type CreateMirrorRequest struct {
 	ProviderFilter      []string `json:"provider_filter,omitempty"`
 	VersionFilter       *string  `json:"version_filter,omitempty"`
 	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	SyncIntervalHours   int      `json:"sync_interval_hours"`
+	Enabled             *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // UpdateMirrorRequest is the payload for updating a mirror.
+//
+// All fields are pointers; only fields the caller explicitly populates are
+// sent on the wire. This matches the backend's UpdateMirrorConfigRequest,
+// where omitted fields leave the existing value unchanged. Sending plain
+// bool/int zero values would silently disable the mirror or reset its sync
+// interval to zero.
 type UpdateMirrorRequest struct {
-	Name                string   `json:"name"`
+	Name                *string  `json:"name,omitempty"`
 	Description         *string  `json:"description,omitempty"`
-	UpstreamRegistryURL string   `json:"upstream_registry_url"`
+	UpstreamRegistryURL *string  `json:"upstream_registry_url,omitempty"`
 	OrganizationID      *string  `json:"organization_id,omitempty"`
 	NamespaceFilter     []string `json:"namespace_filter,omitempty"`
 	ProviderFilter      []string `json:"provider_filter,omitempty"`
 	VersionFilter       *string  `json:"version_filter,omitempty"`
 	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	SyncIntervalHours   int      `json:"sync_interval_hours"`
+	Enabled             *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // TerraformMirror represents a Terraform binary mirror configuration.
@@ -303,31 +314,40 @@ type TerraformMirror struct {
 }
 
 // CreateTerraformMirrorRequest is the payload for creating a Terraform mirror.
+//
+// Optional scalars use pointers so the wire payload omits them when the caller
+// has nothing to set; the backend then applies defaults. See
+// backend/internal/db/models/terraform_mirror.go.
 type CreateTerraformMirrorRequest struct {
 	Name              string   `json:"name"`
 	Description       *string  `json:"description,omitempty"`
 	Tool              string   `json:"tool"`
-	Enabled           bool     `json:"enabled"`
+	Enabled           *bool    `json:"enabled,omitempty"`
 	UpstreamURL       string   `json:"upstream_url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
-	GPGVerify         bool     `json:"gpg_verify"`
-	StableOnly        bool     `json:"stable_only"`
-	SyncIntervalHours int      `json:"sync_interval_hours"`
+	GPGVerify         *bool    `json:"gpg_verify,omitempty"`
+	StableOnly        *bool    `json:"stable_only,omitempty"`
+	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // UpdateTerraformMirrorRequest is the payload for updating a Terraform mirror.
+//
+// All fields are pointers; omitted fields leave the existing value unchanged
+// to match backend UpdateTerraformMirrorConfigRequest semantics. Sending plain
+// bool/int zero values would silently disable the mirror or skip GPG
+// verification.
 type UpdateTerraformMirrorRequest struct {
-	Name              string   `json:"name"`
+	Name              *string  `json:"name,omitempty"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              string   `json:"tool"`
-	Enabled           bool     `json:"enabled"`
-	UpstreamURL       string   `json:"upstream_url"`
+	Tool              *string  `json:"tool,omitempty"`
+	Enabled           *bool    `json:"enabled,omitempty"`
+	UpstreamURL       *string  `json:"upstream_url,omitempty"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
-	GPGVerify         bool     `json:"gpg_verify"`
-	StableOnly        bool     `json:"stable_only"`
-	SyncIntervalHours int      `json:"sync_interval_hours"`
+	GPGVerify         *bool    `json:"gpg_verify,omitempty"`
+	StableOnly        *bool    `json:"stable_only,omitempty"`
+	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // StorageConfig represents a storage backend configuration.

--- a/internal/provider/resource_mirror.go
+++ b/internal/provider/resource_mirror.go
@@ -156,8 +156,14 @@ func (r *MirrorResource) Create(ctx context.Context, req resource.CreateRequest,
 	createReq := client.CreateMirrorRequest{
 		Name:                plan.Name.ValueString(),
 		UpstreamRegistryURL: plan.UpstreamRegistryURL.ValueString(),
-		Enabled:             plan.Enabled.ValueBool(),
-		SyncIntervalHours:   int(plan.SyncIntervalHours.ValueInt64()),
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		createReq.Enabled = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		createReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -220,11 +226,19 @@ func (r *MirrorResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	name := plan.Name.ValueString()
+	upstream := plan.UpstreamRegistryURL.ValueString()
 	updateReq := client.UpdateMirrorRequest{
-		Name:                plan.Name.ValueString(),
-		UpstreamRegistryURL: plan.UpstreamRegistryURL.ValueString(),
-		Enabled:             plan.Enabled.ValueBool(),
-		SyncIntervalHours:   int(plan.SyncIntervalHours.ValueInt64()),
+		Name:                &name,
+		UpstreamRegistryURL: &upstream,
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		updateReq.Enabled = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		updateReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()

--- a/internal/provider/resource_terraform_mirror.go
+++ b/internal/provider/resource_terraform_mirror.go
@@ -153,13 +153,25 @@ func (r *TerraformMirrorResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	createReq := client.CreateTerraformMirrorRequest{
-		Name:              plan.Name.ValueString(),
-		Tool:              plan.Tool.ValueString(),
-		Enabled:           plan.Enabled.ValueBool(),
-		UpstreamURL:       plan.UpstreamURL.ValueString(),
-		GPGVerify:         plan.GPGVerify.ValueBool(),
-		StableOnly:        plan.StableOnly.ValueBool(),
-		SyncIntervalHours: int(plan.SyncIntervalHours.ValueInt64()),
+		Name:        plan.Name.ValueString(),
+		Tool:        plan.Tool.ValueString(),
+		UpstreamURL: plan.UpstreamURL.ValueString(),
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		createReq.Enabled = &v
+	}
+	if !plan.GPGVerify.IsNull() && !plan.GPGVerify.IsUnknown() {
+		v := plan.GPGVerify.ValueBool()
+		createReq.GPGVerify = &v
+	}
+	if !plan.StableOnly.IsNull() && !plan.StableOnly.IsUnknown() {
+		v := plan.StableOnly.ValueBool()
+		createReq.StableOnly = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		createReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -212,14 +224,29 @@ func (r *TerraformMirrorResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	name := plan.Name.ValueString()
+	tool := plan.Tool.ValueString()
+	upstream := plan.UpstreamURL.ValueString()
 	updateReq := client.UpdateTerraformMirrorRequest{
-		Name:              plan.Name.ValueString(),
-		Tool:              plan.Tool.ValueString(),
-		Enabled:           plan.Enabled.ValueBool(),
-		UpstreamURL:       plan.UpstreamURL.ValueString(),
-		GPGVerify:         plan.GPGVerify.ValueBool(),
-		StableOnly:        plan.StableOnly.ValueBool(),
-		SyncIntervalHours: int(plan.SyncIntervalHours.ValueInt64()),
+		Name:        &name,
+		Tool:        &tool,
+		UpstreamURL: &upstream,
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		updateReq.Enabled = &v
+	}
+	if !plan.GPGVerify.IsNull() && !plan.GPGVerify.IsUnknown() {
+		v := plan.GPGVerify.ValueBool()
+		updateReq.GPGVerify = &v
+	}
+	if !plan.StableOnly.IsNull() && !plan.StableOnly.IsUnknown() {
+		v := plan.StableOnly.ValueBool()
+		updateReq.StableOnly = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		updateReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()


### PR DESCRIPTION
Closes #8

## Summary

Backend's `UpdateMirrorConfigRequest` and `UpdateTerraformMirrorConfigRequest` use `*bool` / `*int` internally — omitted fields leave the existing value unchanged. The provider's request structs used plain `bool` / `int`, so on any update Terraform's resource layer would marshal `enabled: false`, `sync_interval_hours: 0`, and (for the Terraform-binary mirror) `gpg_verify: false, stable_only: false` even when those fields weren't part of the user's diff.

This PR:
- Converts optional scalars on both Create and Update request structs to pointers
- Populates them conditionally from the resource layer (`if !plan.X.IsNull() && !plan.X.IsUnknown()`)
- Keeps required fields (`Name`, `UpstreamRegistryURL`, `Tool`, `UpstreamURL`) as plain values
- Adds client unit tests that marshal a partial update request and assert unset fields are absent from the wire payload

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/client/...` — new wire-payload tests pass
- [x] `go test ./internal/provider/...` — existing provider tests pass
- [ ] Acceptance test (CI): create a mirror with `enabled = true`, change only `name`, confirm `enabled` stays true

## Changelog
- fix: mirror and terraform-mirror updates no longer overwrite `enabled` / `sync_interval_hours` / `gpg_verify` with zero values when those attributes are unchanged