### PR TITLE
fix(scm-provider): align model with backend; remove phantom oauth_status

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -175,31 +175,46 @@ type UpdateProviderRecordRequest struct {
 }
 
 // SCMProvider represents an SCM (source control) integration.
+//
+// Mirrors the backend scm.SCMProvider type. ClientID is exposed on the
+// response (not the secret); WebhookSecret is never returned.
 type SCMProvider struct {
-	ID           string  `json:"id"`
-	Name         string  `json:"name"`
-	ProviderType string  `json:"provider_type"`
-	BaseURL      *string `json:"base_url,omitempty"`
-	OAuthStatus  *string `json:"oauth_status,omitempty"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
+	ID             string  `json:"id"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+	Name           string  `json:"name"`
+	ProviderType   string  `json:"provider_type"`
+	BaseURL        *string `json:"base_url,omitempty"`
+	TenantID       *string `json:"tenant_id,omitempty"`
+	ClientID       string  `json:"client_id,omitempty"`
+	IsActive       bool    `json:"is_active"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
 }
 
 // CreateSCMProviderRequest is the payload for creating an SCM provider.
 type CreateSCMProviderRequest struct {
-	Name          string  `json:"name"`
-	ProviderType  string  `json:"provider_type"`
-	BaseURL       *string `json:"base_url,omitempty"`
-	ClientID      string  `json:"client_id,omitempty"`
-	ClientSecret  string  `json:"client_secret,omitempty"`
-	WebhookSecret string  `json:"webhook_secret,omitempty"`
-	TenantID      *string `json:"tenant_id,omitempty"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+	Name           string  `json:"name"`
+	ProviderType   string  `json:"provider_type"`
+	BaseURL        *string `json:"base_url,omitempty"`
+	TenantID       *string `json:"tenant_id,omitempty"`
+	ClientID       string  `json:"client_id,omitempty"`
+	ClientSecret   string  `json:"client_secret,omitempty"`
+	WebhookSecret  string  `json:"webhook_secret,omitempty"`
 }
 
 // UpdateSCMProviderRequest is the payload for updating an SCM provider.
+//
+// All fields are pointers; omitted fields leave the existing value
+// unchanged on the backend.
 type UpdateSCMProviderRequest struct {
-	Name    string  `json:"name"`
-	BaseURL *string `json:"base_url,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	BaseURL       *string `json:"base_url,omitempty"`
+	TenantID      *string `json:"tenant_id,omitempty"`
+	ClientID      *string `json:"client_id,omitempty"`
+	ClientSecret  *string `json:"client_secret,omitempty"`
+	WebhookSecret *string `json:"webhook_secret,omitempty"`
+	IsActive      *bool   `json:"is_active,omitempty"`
 }
 
 // ModuleSCMLink represents a link between a module and an SCM repository.

--- a/internal/client/scm_providers_test.go
+++ b/internal/client/scm_providers_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSCMProvider_DecodesV1Fields guards against the model drift fixed in #9:
+// backend's scm.SCMProvider now exposes organization_id, is_active, tenant_id,
+// and client_id, while the previous provider model expected a phantom
+// oauth_status field that does not exist in the backend.
+func TestSCMProvider_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"provider_type": "github",
+		"name": "main-github",
+		"base_url": "https://github.example.com",
+		"client_id": "abc123",
+		"is_active": true,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var p SCMProvider
+	if err := json.Unmarshal(body, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !p.IsActive {
+		t.Errorf("IsActive = false, want true")
+	}
+	if p.OrganizationID == nil || *p.OrganizationID != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("OrganizationID = %v, want pointer to UUID", p.OrganizationID)
+	}
+	if p.ClientID != "abc123" {
+		t.Errorf("ClientID = %q, want abc123", p.ClientID)
+	}
+}
+
+// TestUpdateSCMProviderRequest_OmitsUnsetFields confirms the pointer-typed
+// update request omits unset optional fields from the wire payload, matching
+// the backend semantics where missing fields are left unchanged.
+func TestUpdateSCMProviderRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateSCMProviderRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	for _, k := range []string{
+		`"base_url"`,
+		`"tenant_id"`,
+		`"client_id"`,
+		`"client_secret"`,
+		`"webhook_secret"`,
+		`"is_active"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}

--- a/internal/provider/datasource_scm_providers.go
+++ b/internal/provider/datasource_scm_providers.go
@@ -21,13 +21,16 @@ type SCMProvidersDataSourceModel struct {
 }
 
 type SCMProviderDSItem struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Type        types.String `tfsdk:"type"`
-	BaseURL     types.String `tfsdk:"base_url"`
-	OAuthStatus types.String `tfsdk:"oauth_status"`
-	CreatedAt   types.String `tfsdk:"created_at"`
-	UpdatedAt   types.String `tfsdk:"updated_at"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Name           types.String `tfsdk:"name"`
+	Type           types.String `tfsdk:"type"`
+	BaseURL        types.String `tfsdk:"base_url"`
+	TenantID       types.String `tfsdk:"tenant_id"`
+	ClientID       types.String `tfsdk:"client_id"`
+	IsActive       types.Bool   `tfsdk:"is_active"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewSCMProvidersDataSource() datasource.DataSource {
@@ -47,13 +50,16 @@ func (d *SCMProvidersDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id":           schema.StringAttribute{Computed: true, Description: "UUID."},
-						"name":         schema.StringAttribute{Computed: true, Description: "Display name."},
-						"type":         schema.StringAttribute{Computed: true, Description: "SCM type."},
-						"base_url":     schema.StringAttribute{Computed: true, Description: "Base URL for self-hosted instances."},
-						"oauth_status": schema.StringAttribute{Computed: true, Description: "OAuth token status."},
-						"created_at":   schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-						"updated_at":   schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
+						"id":              schema.StringAttribute{Computed: true, Description: "UUID."},
+						"organization_id": schema.StringAttribute{Computed: true, Description: "Organization the integration is scoped to (null for global)."},
+						"name":            schema.StringAttribute{Computed: true, Description: "Display name."},
+						"type":            schema.StringAttribute{Computed: true, Description: "SCM type."},
+						"base_url":        schema.StringAttribute{Computed: true, Description: "Base URL for self-hosted instances."},
+						"tenant_id":       schema.StringAttribute{Computed: true, Description: "Azure DevOps tenant ID."},
+						"client_id":       schema.StringAttribute{Computed: true, Description: "OAuth client ID."},
+						"is_active":       schema.BoolAttribute{Computed: true, Description: "Whether the integration is enabled."},
+						"created_at":      schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
+						"updated_at":      schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
 				},
 			},
@@ -92,18 +98,29 @@ func (d *SCMProvidersDataSource) Read(ctx context.Context, req datasource.ReadRe
 			ID:        types.StringValue(s.ID),
 			Name:      types.StringValue(s.Name),
 			Type:      types.StringValue(s.ProviderType),
+			IsActive:  types.BoolValue(s.IsActive),
 			CreatedAt: types.StringValue(s.CreatedAt),
 			UpdatedAt: types.StringValue(s.UpdatedAt),
+		}
+		if s.OrganizationID != nil {
+			item.OrganizationID = types.StringValue(*s.OrganizationID)
+		} else {
+			item.OrganizationID = types.StringNull()
 		}
 		if s.BaseURL != nil {
 			item.BaseURL = types.StringValue(*s.BaseURL)
 		} else {
 			item.BaseURL = types.StringNull()
 		}
-		if s.OAuthStatus != nil {
-			item.OAuthStatus = types.StringValue(*s.OAuthStatus)
+		if s.TenantID != nil {
+			item.TenantID = types.StringValue(*s.TenantID)
 		} else {
-			item.OAuthStatus = types.StringNull()
+			item.TenantID = types.StringNull()
+		}
+		if s.ClientID != "" {
+			item.ClientID = types.StringValue(s.ClientID)
+		} else {
+			item.ClientID = types.StringNull()
 		}
 		items[i] = item
 	}

--- a/internal/provider/resource_scm_provider.go
+++ b/internal/provider/resource_scm_provider.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,15 +22,18 @@ type SCMProviderResource struct {
 }
 
 type SCMProviderResourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	Type         types.String `tfsdk:"type"`
-	BaseURL      types.String `tfsdk:"base_url"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
-	OAuthStatus  types.String `tfsdk:"oauth_status"`
-	CreatedAt    types.String `tfsdk:"created_at"`
-	UpdatedAt    types.String `tfsdk:"updated_at"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Name           types.String `tfsdk:"name"`
+	Type           types.String `tfsdk:"type"`
+	BaseURL        types.String `tfsdk:"base_url"`
+	TenantID       types.String `tfsdk:"tenant_id"`
+	ClientID       types.String `tfsdk:"client_id"`
+	ClientSecret   types.String `tfsdk:"client_secret"`
+	WebhookSecret  types.String `tfsdk:"webhook_secret"`
+	IsActive       types.Bool   `tfsdk:"is_active"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewSCMProviderResource() resource.Resource {
@@ -50,6 +55,14 @@ func (r *SCMProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this SCM integration is scoped to. Omit for a global integration.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"name": schema.StringAttribute{
 				Description: "Display name for this SCM integration.",
 				Required:    true,
@@ -62,22 +75,38 @@ func (r *SCMProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"base_url": schema.StringAttribute{
-				Description: "Base URL for self-hosted SCM instances (e.g., 'https://github.mycompany.com').",
+				Description: "Base URL for self-hosted SCM instances (e.g., 'https://github.mycompany.com'). Required for Bitbucket Data Center.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"tenant_id": schema.StringAttribute{
+				Description: "Tenant ID for Azure DevOps integrations.",
 				Optional:    true,
 				Computed:    true,
 			},
 			"client_id": schema.StringAttribute{
 				Description: "OAuth application client ID. Required for OAuth-based providers (github, gitlab, azure, bitbucket cloud). Not returned after creation.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"client_secret": schema.StringAttribute{
 				Description: "OAuth application client secret. Required for OAuth-based providers. Not returned after creation.",
 				Optional:    true,
 				Sensitive:   true,
 			},
-			"oauth_status": schema.StringAttribute{
-				Description: "Current OAuth token status.",
+			"webhook_secret": schema.StringAttribute{
+				Description: "Shared secret used to validate incoming webhook payloads. Not returned after creation.",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"is_active": schema.BoolAttribute{
+				Description: "Whether the SCM integration is enabled. Defaults to true.",
+				Optional:    true,
 				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the SCM provider was created.",
@@ -117,15 +146,26 @@ func (r *SCMProviderResource) Create(ctx context.Context, req resource.CreateReq
 		Name:         plan.Name.ValueString(),
 		ProviderType: plan.Type.ValueString(),
 	}
+	if !plan.OrganizationID.IsNull() && !plan.OrganizationID.IsUnknown() {
+		v := plan.OrganizationID.ValueString()
+		createReq.OrganizationID = &v
+	}
 	if !plan.BaseURL.IsNull() && !plan.BaseURL.IsUnknown() {
 		v := plan.BaseURL.ValueString()
 		createReq.BaseURL = &v
+	}
+	if !plan.TenantID.IsNull() && !plan.TenantID.IsUnknown() {
+		v := plan.TenantID.ValueString()
+		createReq.TenantID = &v
 	}
 	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
 		createReq.ClientID = plan.ClientID.ValueString()
 	}
 	if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() {
 		createReq.ClientSecret = plan.ClientSecret.ValueString()
+	}
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		createReq.WebhookSecret = plan.WebhookSecret.ValueString()
 	}
 
 	scm, err := r.client.CreateSCMProvider(ctx, createReq)
@@ -135,9 +175,10 @@ func (r *SCMProviderResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from plan — not returned by API
-	model.ClientID = plan.ClientID
+	// Preserve write-only credentials from plan — backend never returns the
+	// secret values after creation.
 	model.ClientSecret = plan.ClientSecret
+	model.WebhookSecret = plan.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -159,9 +200,9 @@ func (r *SCMProviderResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from state — not returned by API
-	model.ClientID = state.ClientID
+	// Preserve write-only secrets from state — not returned by API.
 	model.ClientSecret = state.ClientSecret
+	model.WebhookSecret = state.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -174,12 +215,33 @@ func (r *SCMProviderResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	name := plan.Name.ValueString()
 	updateReq := client.UpdateSCMProviderRequest{
-		Name: plan.Name.ValueString(),
+		Name: &name,
 	}
 	if !plan.BaseURL.IsNull() && !plan.BaseURL.IsUnknown() {
 		v := plan.BaseURL.ValueString()
 		updateReq.BaseURL = &v
+	}
+	if !plan.TenantID.IsNull() && !plan.TenantID.IsUnknown() {
+		v := plan.TenantID.ValueString()
+		updateReq.TenantID = &v
+	}
+	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
+		v := plan.ClientID.ValueString()
+		updateReq.ClientID = &v
+	}
+	if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() {
+		v := plan.ClientSecret.ValueString()
+		updateReq.ClientSecret = &v
+	}
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		v := plan.WebhookSecret.ValueString()
+		updateReq.WebhookSecret = &v
+	}
+	if !plan.IsActive.IsNull() && !plan.IsActive.IsUnknown() {
+		v := plan.IsActive.ValueBool()
+		updateReq.IsActive = &v
 	}
 
 	scm, err := r.client.UpdateSCMProvider(ctx, plan.ID.ValueString(), updateReq)
@@ -189,9 +251,9 @@ func (r *SCMProviderResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from plan (or fall back to state)
-	model.ClientID = plan.ClientID
+	// Preserve write-only secrets from plan — not returned by API.
 	model.ClientSecret = plan.ClientSecret
+	model.WebhookSecret = plan.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -214,9 +276,9 @@ func (r *SCMProviderResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 	model := scmProviderToModel(scm)
-	// Credentials are not recoverable on import
-	model.ClientID = types.StringNull()
+	// Secrets are never returned by the API and cannot be recovered on import.
 	model.ClientSecret = types.StringNull()
+	model.WebhookSecret = types.StringNull()
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -225,18 +287,29 @@ func scmProviderToModel(s *client.SCMProvider) SCMProviderResourceModel {
 		ID:        types.StringValue(s.ID),
 		Name:      types.StringValue(s.Name),
 		Type:      types.StringValue(s.ProviderType),
+		IsActive:  types.BoolValue(s.IsActive),
 		CreatedAt: types.StringValue(normalizeTimestamp(s.CreatedAt)),
 		UpdatedAt: types.StringValue(normalizeTimestamp(s.UpdatedAt)),
+	}
+	if s.OrganizationID != nil {
+		model.OrganizationID = types.StringValue(*s.OrganizationID)
+	} else {
+		model.OrganizationID = types.StringNull()
 	}
 	if s.BaseURL != nil {
 		model.BaseURL = types.StringValue(*s.BaseURL)
 	} else {
 		model.BaseURL = types.StringNull()
 	}
-	if s.OAuthStatus != nil {
-		model.OAuthStatus = types.StringValue(*s.OAuthStatus)
+	if s.TenantID != nil {
+		model.TenantID = types.StringValue(*s.TenantID)
 	} else {
-		model.OAuthStatus = types.StringNull()
+		model.TenantID = types.StringNull()
+	}
+	if s.ClientID != "" {
+		model.ClientID = types.StringValue(s.ClientID)
+	} else {
+		model.ClientID = types.StringNull()
 	}
 	return model
 }


### PR DESCRIPTION
Closes #9

## Summary

The provider's `SCMProvider` model carried an `oauth_status` field that does **not exist anywhere in the backend codebase** (verified via grep — no DB column, no JSON tag, no handler reference). It was always null, so anyone using `registry_scm_provider.x.oauth_status` was reading dead state.

Meanwhile the real backend response (`backend/internal/scm/types.go:155`) exposes `organization_id`, `is_active`, `tenant_id`, and a populated `client_id` — none of which the provider modelled.

This PR:

- Replaces `OAuthStatus` on `client.SCMProvider` with the real backend fields.
- Adds `organization_id` to `CreateSCMProviderRequest`.
- Converts `UpdateSCMProviderRequest` to all-pointer fields so omitted attributes leave existing values unchanged on the backend (same pattern as #8 / PR #36).
- Surfaces `organization_id`, `tenant_id`, `client_id`, `is_active`, and `webhook_secret` on `registry_scm_provider`; removes `oauth_status`.
- Mirrors the field changes on `data.registry_scm_providers`.
- Preserves write-only `client_secret` / `webhook_secret` in state since the API never returns them.

### Breaking change for consumers of `oauth_status`

Anyone referencing `registry_scm_provider.x.oauth_status` (or `data.registry_scm_providers.scm_providers[0].oauth_status`) will need to remove that reference. Since the value has always been null in practice, the practical blast radius is near zero — but the schema removal will produce a plan-time error in any config that depended on it.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/client/...` — round-trip + wire-payload tests pass
- [x] `go test ./internal/provider/...` — existing tests pass
- [ ] Acceptance test (CI): create an SCM provider with `is_active = false`, verify state matches; update name only, verify other fields stay put
- [ ] Regenerate docs (`make docs`) before merge

## Changelog
- fix!: `registry_scm_provider` exposes `is_active`, `organization_id`, `tenant_id`, `client_id`, `webhook_secret`; phantom `oauth_status` removed
- fix: SCM provider update no longer overwrites unrelated fields with zero values