### PR TITLE
fix(module-scm-link): add repository_path and auto_publish_enabled

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -203,6 +203,12 @@ type UpdateSCMProviderRequest struct {
 }
 
 // ModuleSCMLink represents a link between a module and an SCM repository.
+//
+// JSON field naming on read intentionally differs from the create/update
+// request bodies: the response carries module_path / auto_publish_enabled
+// while the request bodies use repository_path / auto_publish_enabled.
+// See backend/internal/scm/types.go (response) and
+// backend/internal/api/modules/scm_linking.go (request).
 type ModuleSCMLink struct {
 	ID              string `json:"id"`
 	ModuleID        string `json:"module_id"`
@@ -210,18 +216,26 @@ type ModuleSCMLink struct {
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	ModulePath      string `json:"module_path"`
 	TagPattern      string `json:"tag_pattern"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 	CreatedAt       string `json:"created_at"`
 	UpdatedAt       string `json:"updated_at"`
 }
 
 // CreateModuleSCMLinkRequest is the payload for creating a module SCM link.
+//
+// Note the request field is repository_path, not module_path; the backend
+// renames it on persist. See LinkSCMRequest in
+// backend/internal/api/modules/scm_linking.go.
 type CreateModuleSCMLinkRequest struct {
 	SCMProviderID   string `json:"provider_id"`
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	RepositoryPath  string `json:"repository_path,omitempty"`
 	TagPattern      string `json:"tag_pattern,omitempty"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 }
 
 // UpdateModuleSCMLinkRequest is the payload for updating a module SCM link.
@@ -230,7 +244,9 @@ type UpdateModuleSCMLinkRequest struct {
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	RepositoryPath  string `json:"repository_path,omitempty"`
 	TagPattern      string `json:"tag_pattern,omitempty"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 }
 
 // Mirror represents a provider mirror configuration.

--- a/internal/client/module_scm_links_test.go
+++ b/internal/client/module_scm_links_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestModuleSCMLink_DecodesV1Fields covers the fix in #10 — backend's response
+// model carries module_path and auto_publish_enabled, which the previous
+// provider client struct was missing entirely.
+func TestModuleSCMLink_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"module_id": "22222222-2222-2222-2222-222222222222",
+		"scm_provider_id": "33333333-3333-3333-3333-333333333333",
+		"repository_owner": "acme",
+		"repository_name": "vpc",
+		"default_branch": "main",
+		"module_path": "modules/vpc",
+		"tag_pattern": "v*",
+		"auto_publish_enabled": true,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var l ModuleSCMLink
+	if err := json.Unmarshal(body, &l); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if l.ModulePath != "modules/vpc" {
+		t.Errorf("ModulePath = %q, want modules/vpc (json tag must be module_path)", l.ModulePath)
+	}
+	if !l.AutoPublish {
+		t.Errorf("AutoPublish = false, want true (json tag must be auto_publish_enabled)")
+	}
+}
+
+// TestCreateModuleSCMLinkRequest_UsesRepositoryPath asserts the asymmetric
+// naming on the request side: backend's LinkSCMRequest accepts
+// repository_path (the request renames module_path on persist) and
+// auto_publish_enabled.
+func TestCreateModuleSCMLinkRequest_UsesRepositoryPath(t *testing.T) {
+	req := CreateModuleSCMLinkRequest{
+		SCMProviderID:   "p",
+		RepositoryOwner: "acme",
+		RepositoryName:  "vpc",
+		DefaultBranch:   "main",
+		RepositoryPath:  "modules/vpc",
+		AutoPublish:     true,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"repository_path":"modules/vpc"`) {
+		t.Errorf("missing repository_path on the wire: %s", wire)
+	}
+	if !strings.Contains(wire, `"auto_publish_enabled":true`) {
+		t.Errorf("missing auto_publish_enabled on the wire: %s", wire)
+	}
+	if strings.Contains(wire, `"module_path"`) {
+		t.Errorf("request body should not use module_path (response-side name): %s", wire)
+	}
+}

--- a/internal/provider/resource_module_scm_link.go
+++ b/internal/provider/resource_module_scm_link.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -20,14 +22,16 @@ type ModuleSCMLinkResource struct {
 }
 
 type ModuleSCMLinkResourceModel struct {
-	ModuleID      types.String `tfsdk:"module_id"`
-	SCMProviderID types.String `tfsdk:"scm_provider_id"`
-	Owner         types.String `tfsdk:"owner"`
-	Repo          types.String `tfsdk:"repo"`
-	Branch        types.String `tfsdk:"branch"`
-	TagPattern    types.String `tfsdk:"tag_pattern"`
-	CreatedAt     types.String `tfsdk:"created_at"`
-	UpdatedAt     types.String `tfsdk:"updated_at"`
+	ModuleID       types.String `tfsdk:"module_id"`
+	SCMProviderID  types.String `tfsdk:"scm_provider_id"`
+	Owner          types.String `tfsdk:"owner"`
+	Repo           types.String `tfsdk:"repo"`
+	Branch         types.String `tfsdk:"branch"`
+	RepositoryPath types.String `tfsdk:"repository_path"`
+	TagPattern     types.String `tfsdk:"tag_pattern"`
+	AutoPublish    types.Bool   `tfsdk:"auto_publish_enabled"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewModuleSCMLinkResource() resource.Resource {
@@ -65,10 +69,22 @@ func (r *ModuleSCMLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Description: "Default branch to watch.",
 				Required:    true,
 			},
+			"repository_path": schema.StringAttribute{
+				Description: "Path within the repository where the module sources live. Defaults to '/' (repo root). Use this for monorepo layouts.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("/"),
+			},
 			"tag_pattern": schema.StringAttribute{
 				Description: "Optional glob pattern for version tags (e.g., 'v*').",
 				Optional:    true,
 				Computed:    true,
+			},
+			"auto_publish_enabled": schema.BoolAttribute{
+				Description: "Whether to automatically publish a new module version when a matching tag is pushed. Defaults to false.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the link was created.",
@@ -109,6 +125,10 @@ func (r *ModuleSCMLinkResource) Create(ctx context.Context, req resource.CreateR
 		RepositoryOwner: plan.Owner.ValueString(),
 		RepositoryName:  plan.Repo.ValueString(),
 		DefaultBranch:   plan.Branch.ValueString(),
+		AutoPublish:     plan.AutoPublish.ValueBool(),
+	}
+	if !plan.RepositoryPath.IsNull() && !plan.RepositoryPath.IsUnknown() {
+		createReq.RepositoryPath = plan.RepositoryPath.ValueString()
 	}
 	if !plan.TagPattern.IsNull() && !plan.TagPattern.IsUnknown() {
 		createReq.TagPattern = plan.TagPattern.ValueString()
@@ -155,6 +175,10 @@ func (r *ModuleSCMLinkResource) Update(ctx context.Context, req resource.UpdateR
 		RepositoryOwner: plan.Owner.ValueString(),
 		RepositoryName:  plan.Repo.ValueString(),
 		DefaultBranch:   plan.Branch.ValueString(),
+		AutoPublish:     plan.AutoPublish.ValueBool(),
+	}
+	if !plan.RepositoryPath.IsNull() && !plan.RepositoryPath.IsUnknown() {
+		updateReq.RepositoryPath = plan.RepositoryPath.ValueString()
 	}
 	if !plan.TagPattern.IsNull() && !plan.TagPattern.IsUnknown() {
 		updateReq.TagPattern = plan.TagPattern.ValueString()
@@ -192,13 +216,15 @@ func (r *ModuleSCMLinkResource) ImportState(ctx context.Context, req resource.Im
 
 func moduleSCMLinkToModel(l *client.ModuleSCMLink) ModuleSCMLinkResourceModel {
 	model := ModuleSCMLinkResourceModel{
-		ModuleID:      types.StringValue(l.ModuleID),
-		SCMProviderID: types.StringValue(l.SCMProviderID),
-		Owner:         types.StringValue(l.RepositoryOwner),
-		Repo:          types.StringValue(l.RepositoryName),
-		Branch:        types.StringValue(l.DefaultBranch),
-		CreatedAt:     types.StringValue(l.CreatedAt),
-		UpdatedAt:     types.StringValue(l.UpdatedAt),
+		ModuleID:       types.StringValue(l.ModuleID),
+		SCMProviderID:  types.StringValue(l.SCMProviderID),
+		Owner:          types.StringValue(l.RepositoryOwner),
+		Repo:           types.StringValue(l.RepositoryName),
+		Branch:         types.StringValue(l.DefaultBranch),
+		RepositoryPath: types.StringValue(l.ModulePath),
+		AutoPublish:    types.BoolValue(l.AutoPublish),
+		CreatedAt:      types.StringValue(l.CreatedAt),
+		UpdatedAt:      types.StringValue(l.UpdatedAt),
 	}
 	if l.TagPattern != "" {
 		model.TagPattern = types.StringValue(l.TagPattern)


### PR DESCRIPTION
Closes #10

## Summary

The provider's `ModuleSCMLink` model was missing two fields the backend already supports:

- `module_path` (read) / `repository_path` (write) — the path within the repo where the module sources live; required for monorepo layouts
- `auto_publish_enabled` — whether to auto-publish a new module version on tag push

The asymmetric naming (response uses `module_path`, request uses `repository_path`) is intentional in the backend — the request handler renames it on persist (see `LinkSCMRequest` in `backend/internal/api/modules/scm_linking.go:39` vs `ModuleSCMRepo` in `backend/internal/scm/types.go:193`). The Go client struct now carries both names on the appropriate sides.

This PR:

- Adds `ModulePath` to `client.ModuleSCMLink` (read).
- Adds `RepositoryPath` and `AutoPublish` to `CreateModuleSCMLinkRequest` / `UpdateModuleSCMLinkRequest`.
- Surfaces `repository_path` (default `/`) and `auto_publish_enabled` (default `false`) on `registry_module_scm_link`.
- Round-trips the read-side `module_path` into state.
- Adds client unit tests asserting the asymmetric request/response naming.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/client/...` — new round-trip + wire-naming tests pass
- [x] `go test ./internal/provider/...` — existing tests pass
- [ ] Acceptance test (CI): create a link with `repository_path = \"modules/vpc\"` and `auto_publish_enabled = true`, confirm both round-trip

## Changelog
- feat: `registry_module_scm_link` exposes `repository_path` (monorepo support) and `auto_publish_enabled`