### PR TITLE
feat(approval-request): expose new backend fields

### DIFF
--- a/internal/client/approval_requests_test.go
+++ b/internal/client/approval_requests_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestApprovalRequest_DecodesV1Fields covers the field expansion in #11 —
+// backend's MirrorApprovalRequest now returns organization_id, requested_by,
+// reviewed_at, expires_at, plus joined requested_by_name / reviewed_by_name /
+// mirror_name fields, none of which the previous client struct knew about.
+func TestApprovalRequest_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"mirror_config_id": "22222222-2222-2222-2222-222222222222",
+		"organization_id": "33333333-3333-3333-3333-333333333333",
+		"requested_by": "44444444-4444-4444-4444-444444444444",
+		"provider_namespace": "hashicorp",
+		"provider_name": "aws",
+		"reason": "needed for prod",
+		"status": "approved",
+		"reviewed_by": "55555555-5555-5555-5555-555555555555",
+		"reviewed_at": "2026-04-30T01:00:00Z",
+		"review_notes": "ok",
+		"auto_approved": false,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T01:00:00Z",
+		"expires_at": "2027-04-30T00:00:00Z",
+		"requested_by_name": "Alice",
+		"reviewed_by_name": "Bob",
+		"mirror_name": "hashicorp-prod"
+	}`)
+
+	var ar ApprovalRequest
+	if err := json.Unmarshal(body, &ar); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ar.OrganizationID == nil || *ar.OrganizationID != "33333333-3333-3333-3333-333333333333" {
+		t.Errorf("OrganizationID = %v, want UUID pointer", ar.OrganizationID)
+	}
+	if ar.RequestedBy == nil || *ar.RequestedBy != "44444444-4444-4444-4444-444444444444" {
+		t.Errorf("RequestedBy = %v", ar.RequestedBy)
+	}
+	if ar.ReviewedAt == nil || *ar.ReviewedAt != "2026-04-30T01:00:00Z" {
+		t.Errorf("ReviewedAt = %v", ar.ReviewedAt)
+	}
+	if ar.ExpiresAt == nil || *ar.ExpiresAt != "2027-04-30T00:00:00Z" {
+		t.Errorf("ExpiresAt = %v", ar.ExpiresAt)
+	}
+	if ar.RequestedByName != "Alice" {
+		t.Errorf("RequestedByName = %q", ar.RequestedByName)
+	}
+	if ar.ReviewedByName != "Bob" {
+		t.Errorf("ReviewedByName = %q", ar.ReviewedByName)
+	}
+	if ar.MirrorName != "hashicorp-prod" {
+		t.Errorf("MirrorName = %q", ar.MirrorName)
+	}
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -466,18 +466,33 @@ type UpdatePolicyRequest struct {
 }
 
 // ApprovalRequest represents a mirror approval request.
+//
+// Mirrors backend's MirrorApprovalRequest in
+// backend/internal/db/models/mirror_approval.go. The OrganizationID,
+// RequestedBy, ReviewedAt, ExpiresAt, RequestedByName, ReviewedByName,
+// and MirrorName fields are populated by the backend on read; none of
+// them are accepted on the create payload.
 type ApprovalRequest struct {
 	ID                string  `json:"id"`
 	MirrorConfigID    string  `json:"mirror_config_id"`
+	OrganizationID    *string `json:"organization_id,omitempty"`
+	RequestedBy       *string `json:"requested_by,omitempty"`
 	ProviderNamespace string  `json:"provider_namespace"`
 	ProviderName      *string `json:"provider_name,omitempty"`
 	Reason            string  `json:"reason,omitempty"`
 	Status            string  `json:"status"`
 	ReviewedBy        *string `json:"reviewed_by,omitempty"`
+	ReviewedAt        *string `json:"reviewed_at,omitempty"`
 	ReviewNotes       *string `json:"review_notes,omitempty"`
 	AutoApproved      bool    `json:"auto_approved"`
 	CreatedAt         string  `json:"created_at"`
 	UpdatedAt         string  `json:"updated_at"`
+	ExpiresAt         *string `json:"expires_at,omitempty"`
+
+	// Joined fields (populated server-side via LEFT JOIN; never written).
+	RequestedByName string `json:"requested_by_name,omitempty"`
+	ReviewedByName  string `json:"reviewed_by_name,omitempty"`
+	MirrorName      string `json:"mirror_name,omitempty"`
 }
 
 // CreateApprovalRequestRequest is the payload for creating an approval request.

--- a/internal/provider/resource_approval_request.go
+++ b/internal/provider/resource_approval_request.go
@@ -22,12 +22,20 @@ type ApprovalRequestResource struct {
 type ApprovalRequestResourceModel struct {
 	ID                types.String `tfsdk:"id"`
 	MirrorID          types.String `tfsdk:"mirror_id"`
+	OrganizationID    types.String `tfsdk:"organization_id"`
 	ProviderNamespace types.String `tfsdk:"provider_namespace"`
 	ProviderName      types.String `tfsdk:"provider_name"`
 	Justification     types.String `tfsdk:"justification"`
 	ReviewStatus      types.String `tfsdk:"review_status"`
+	RequestedBy       types.String `tfsdk:"requested_by"`
+	RequestedByName   types.String `tfsdk:"requested_by_name"`
 	ReviewerID        types.String `tfsdk:"reviewer_id"`
+	ReviewerName      types.String `tfsdk:"reviewer_name"`
+	ReviewedAt        types.String `tfsdk:"reviewed_at"`
 	ReviewNote        types.String `tfsdk:"review_note"`
+	ExpiresAt         types.String `tfsdk:"expires_at"`
+	AutoApproved      types.Bool   `tfsdk:"auto_approved"`
+	MirrorName        types.String `tfsdk:"mirror_name"`
 	CreatedAt         types.String `tfsdk:"created_at"`
 	UpdatedAt         types.String `tfsdk:"updated_at"`
 }
@@ -81,16 +89,48 @@ func (r *ApprovalRequestResource) Schema(_ context.Context, _ resource.SchemaReq
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this request was scoped to (null for global).",
+				Computed:    true,
+			},
 			"review_status": schema.StringAttribute{
 				Description: "Current review status: pending, approved, or rejected.",
+				Computed:    true,
+			},
+			"requested_by": schema.StringAttribute{
+				Description: "UUID of the user who created the request.",
+				Computed:    true,
+			},
+			"requested_by_name": schema.StringAttribute{
+				Description: "Display name of the requesting user.",
 				Computed:    true,
 			},
 			"reviewer_id": schema.StringAttribute{
 				Description: "UUID of the reviewing user.",
 				Computed:    true,
 			},
+			"reviewer_name": schema.StringAttribute{
+				Description: "Display name of the reviewing user.",
+				Computed:    true,
+			},
+			"reviewed_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the request was reviewed.",
+				Computed:    true,
+			},
 			"review_note": schema.StringAttribute{
 				Description: "Note from the reviewer.",
+				Computed:    true,
+			},
+			"expires_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when an approved request expires; null if it does not expire.",
+				Computed:    true,
+			},
+			"auto_approved": schema.BoolAttribute{
+				Description: "True if the request was auto-approved by a matching policy.",
+				Computed:    true,
+			},
+			"mirror_name": schema.StringAttribute{
+				Description: "Name of the mirror this approval request applies to.",
 				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
@@ -200,6 +240,7 @@ func approvalRequestToModel(a *client.ApprovalRequest) ApprovalRequestResourceMo
 		ProviderNamespace: types.StringValue(a.ProviderNamespace),
 		Justification:     types.StringValue(a.Reason),
 		ReviewStatus:      types.StringValue(a.Status),
+		AutoApproved:      types.BoolValue(a.AutoApproved),
 		CreatedAt:         types.StringValue(normalizeTimestamp(a.CreatedAt)),
 		UpdatedAt:         types.StringValue(normalizeTimestamp(a.UpdatedAt)),
 	}
@@ -208,15 +249,50 @@ func approvalRequestToModel(a *client.ApprovalRequest) ApprovalRequestResourceMo
 	} else {
 		model.ProviderName = types.StringNull()
 	}
+	if a.OrganizationID != nil {
+		model.OrganizationID = types.StringValue(*a.OrganizationID)
+	} else {
+		model.OrganizationID = types.StringNull()
+	}
+	if a.RequestedBy != nil {
+		model.RequestedBy = types.StringValue(*a.RequestedBy)
+	} else {
+		model.RequestedBy = types.StringNull()
+	}
+	if a.RequestedByName != "" {
+		model.RequestedByName = types.StringValue(a.RequestedByName)
+	} else {
+		model.RequestedByName = types.StringNull()
+	}
 	if a.ReviewedBy != nil {
 		model.ReviewerID = types.StringValue(*a.ReviewedBy)
 	} else {
 		model.ReviewerID = types.StringNull()
 	}
+	if a.ReviewedByName != "" {
+		model.ReviewerName = types.StringValue(a.ReviewedByName)
+	} else {
+		model.ReviewerName = types.StringNull()
+	}
+	if a.ReviewedAt != nil {
+		model.ReviewedAt = types.StringValue(normalizeTimestamp(*a.ReviewedAt))
+	} else {
+		model.ReviewedAt = types.StringNull()
+	}
 	if a.ReviewNotes != nil {
 		model.ReviewNote = types.StringValue(*a.ReviewNotes)
 	} else {
 		model.ReviewNote = types.StringNull()
+	}
+	if a.ExpiresAt != nil {
+		model.ExpiresAt = types.StringValue(normalizeTimestamp(*a.ExpiresAt))
+	} else {
+		model.ExpiresAt = types.StringNull()
+	}
+	if a.MirrorName != "" {
+		model.MirrorName = types.StringValue(a.MirrorName)
+	} else {
+		model.MirrorName = types.StringNull()
 	}
 	return model
 }


### PR DESCRIPTION
Closes #11

## Summary

Backend's `MirrorApprovalRequest` (`backend/internal/db/models/mirror_approval.go`) now returns more fields than the provider modelled:

- `organization_id` — request scope (null for global)
- `requested_by` — UUID of requester
- `reviewed_at` — review timestamp
- `expires_at` — approval expiry, if any
- `auto_approved` — matched a policy
- joined: `requested_by_name`, `reviewed_by_name`, `mirror_name`

Adds these to `client.ApprovalRequest` and surfaces them as computed-only attributes on `registry_approval_request`. None are user-settable on create — the backend assigns `requested_by` from the auth context, `expires_at` from policy, etc.

This is read-only enrichment; existing users see no plan changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/client/...` — new round-trip test passes
- [x] `go test ./internal/provider/...` — existing tests pass
- [ ] Acceptance test (CI): create an approval request, verify computed fields populate after admin review

## Changelog
- feat: `registry_approval_request` exposes `organization_id`, `requested_by`, `requested_by_name`, `reviewer_name`, `reviewed_at`, `review_note`, `expires_at`, `auto_approved`, `mirror_name`