### PR TITLE
fix(stats)!: reshape registry_stats to match backend DashboardStats

### DIFF
--- a/examples/data-sources/registry_stats/data-source.tf
+++ b/examples/data-sources/registry_stats/data-source.tf
@@ -1,9 +1,21 @@
 data "registry_stats" "dashboard" {}
 
 output "total_modules" {
-  value = data.registry_stats.dashboard.total_modules
+  value = data.registry_stats.dashboard.modules.total
 }
 
 output "total_providers" {
-  value = data.registry_stats.dashboard.total_providers
+  value = data.registry_stats.dashboard.providers.total
+}
+
+output "total_users" {
+  value = data.registry_stats.dashboard.users
+}
+
+output "manual_provider_versions" {
+  value = data.registry_stats.dashboard.providers.manual_versions
+}
+
+output "binary_mirrors_healthy" {
+  value = data.registry_stats.dashboard.binary_mirrors.healthy
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -569,12 +569,81 @@ type AuditLog struct {
 	CreatedAt      string                 `json:"created_at"`
 }
 
-// Stats represents dashboard statistics.
+// Stats mirrors backend admin.DashboardStats. The shape was reworked
+// alongside the v1 backend release: counters are now grouped under
+// per-resource sub-objects with separate totals for versions, downloads,
+// and (for providers) manual vs. mirrored counts. The previous flat
+// counters (total_modules, total_users, ...) are no longer returned.
 type Stats struct {
-	TotalModules   int `json:"total_modules"`
-	TotalProviders int `json:"total_providers"`
-	TotalUsers     int `json:"total_users"`
-	TotalOrgs      int `json:"total_organizations"`
-	TotalMirrors   int `json:"total_mirrors"`
-	TotalAPIKeys   int `json:"total_api_keys"`
+	Modules         ModuleStats         `json:"modules"`
+	Providers       ProviderStats       `json:"providers"`
+	ProviderMirrors ProviderMirrorStats `json:"provider_mirrors"`
+	BinaryMirrors   BinaryMirrorStats   `json:"binary_mirrors"`
+	Users           int                 `json:"users"`
+	Organizations   int                 `json:"organizations"`
+	SCMProviders    int                 `json:"scm_providers"`
+	Downloads       int64               `json:"downloads"`
+	RecentSyncs     []RecentSyncEntry   `json:"recent_syncs"`
+}
+
+// ModuleStats is the modules sub-object of dashboard stats.
+type ModuleStats struct {
+	Total     int                `json:"total"`
+	Versions  int                `json:"versions"`
+	Downloads int64              `json:"downloads"`
+	BySystem  []ModuleSystemStat `json:"by_system,omitempty"`
+}
+
+// ModuleSystemStat is one entry in the modules.by_system breakdown.
+type ModuleSystemStat struct {
+	System string `json:"system"`
+	Count  int    `json:"count"`
+}
+
+// ProviderStats is the providers sub-object of dashboard stats.
+type ProviderStats struct {
+	Total            int   `json:"total"`
+	TotalVersions    int   `json:"total_versions"`
+	Manual           int   `json:"manual"`
+	ManualVersions   int   `json:"manual_versions"`
+	Mirrored         int   `json:"mirrored"`
+	MirroredVersions int   `json:"mirrored_versions"`
+	Downloads        int64 `json:"downloads"`
+}
+
+// ProviderMirrorStats is the provider_mirrors sub-object.
+type ProviderMirrorStats struct {
+	Total   int `json:"total"`
+	Healthy int `json:"healthy"`
+	Failed  int `json:"failed"`
+}
+
+// BinaryMirrorStats is the binary_mirrors (Terraform/OpenTofu) sub-object.
+type BinaryMirrorStats struct {
+	Total     int                `json:"total"`
+	Healthy   int                `json:"healthy"`
+	Failed    int                `json:"failed"`
+	Syncing   int                `json:"syncing"`
+	Downloads int64              `json:"downloads"`
+	Platforms int                `json:"platforms"`
+	ByTool    []BinaryToolStat   `json:"by_tool,omitempty"`
+}
+
+// BinaryToolStat is one entry in binary_mirrors.by_tool.
+type BinaryToolStat struct {
+	Tool  string `json:"tool"`
+	Count int    `json:"count"`
+}
+
+// RecentSyncEntry is one row of the recent_syncs ledger across all mirror
+// types (provider mirrors + binary mirrors).
+type RecentSyncEntry struct {
+	MirrorName      string `json:"mirror_name"`
+	MirrorType      string `json:"mirror_type"` // "binary" | "provider"
+	Status          string `json:"status"`
+	TriggeredBy     string `json:"triggered_by"`
+	StartedAt       string `json:"started_at"`
+	CompletedAt     string `json:"completed_at,omitempty"`
+	VersionsSynced  int    `json:"versions_synced"`
+	PlatformsSynced int    `json:"platforms_synced"`
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -620,13 +620,13 @@ type ProviderMirrorStats struct {
 
 // BinaryMirrorStats is the binary_mirrors (Terraform/OpenTofu) sub-object.
 type BinaryMirrorStats struct {
-	Total     int                `json:"total"`
-	Healthy   int                `json:"healthy"`
-	Failed    int                `json:"failed"`
-	Syncing   int                `json:"syncing"`
-	Downloads int64              `json:"downloads"`
-	Platforms int                `json:"platforms"`
-	ByTool    []BinaryToolStat   `json:"by_tool,omitempty"`
+	Total     int              `json:"total"`
+	Healthy   int              `json:"healthy"`
+	Failed    int              `json:"failed"`
+	Syncing   int              `json:"syncing"`
+	Downloads int64            `json:"downloads"`
+	Platforms int              `json:"platforms"`
+	ByTool    []BinaryToolStat `json:"by_tool,omitempty"`
 }
 
 // BinaryToolStat is one entry in binary_mirrors.by_tool.

--- a/internal/client/stats_test.go
+++ b/internal/client/stats_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStats_DecodesDashboardShape covers the major reshape in #7 — the
+// backend's admin.DashboardStats response replaced the flat total_* counters
+// with per-resource sub-objects. The previous client.Stats struct read every
+// field as zero against the v1 backend.
+func TestStats_DecodesDashboardShape(t *testing.T) {
+	body := []byte(`{
+		"users": 42,
+		"organizations": 7,
+		"scm_providers": 3,
+		"downloads": 12345,
+		"modules": {
+			"total": 100,
+			"versions": 350,
+			"downloads": 5000,
+			"by_system": [
+				{"system": "aws", "count": 60},
+				{"system": "azurerm", "count": 40}
+			]
+		},
+		"providers": {
+			"total": 25,
+			"total_versions": 120,
+			"manual": 5,
+			"manual_versions": 30,
+			"mirrored": 20,
+			"mirrored_versions": 90,
+			"downloads": 7000
+		},
+		"provider_mirrors": {
+			"total": 4,
+			"healthy": 3,
+			"failed": 1
+		},
+		"binary_mirrors": {
+			"total": 2,
+			"healthy": 2,
+			"failed": 0,
+			"syncing": 0,
+			"downloads": 345,
+			"platforms": 18,
+			"by_tool": [
+				{"tool": "terraform", "count": 1},
+				{"tool": "opentofu", "count": 1}
+			]
+		},
+		"recent_syncs": [
+			{
+				"mirror_name": "hashicorp",
+				"mirror_type": "provider",
+				"status": "success",
+				"triggered_by": "scheduler",
+				"started_at": "2026-04-30T00:00:00Z",
+				"completed_at": "2026-04-30T00:05:00Z",
+				"versions_synced": 12,
+				"platforms_synced": 0
+			}
+		]
+	}`)
+
+	var s Stats
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if s.Users != 42 {
+		t.Errorf("Users = %d, want 42", s.Users)
+	}
+	if s.Modules.Total != 100 {
+		t.Errorf("Modules.Total = %d, want 100", s.Modules.Total)
+	}
+	if s.Modules.Downloads != 5000 {
+		t.Errorf("Modules.Downloads = %d, want 5000", s.Modules.Downloads)
+	}
+	if got := len(s.Modules.BySystem); got != 2 {
+		t.Errorf("Modules.BySystem len = %d, want 2", got)
+	}
+	if s.Providers.Manual != 5 || s.Providers.Mirrored != 20 {
+		t.Errorf("Providers manual/mirrored = %d/%d, want 5/20",
+			s.Providers.Manual, s.Providers.Mirrored)
+	}
+	if s.ProviderMirrors.Healthy != 3 {
+		t.Errorf("ProviderMirrors.Healthy = %d, want 3", s.ProviderMirrors.Healthy)
+	}
+	if s.BinaryMirrors.Platforms != 18 {
+		t.Errorf("BinaryMirrors.Platforms = %d, want 18", s.BinaryMirrors.Platforms)
+	}
+	if got := len(s.RecentSyncs); got != 1 {
+		t.Fatalf("RecentSyncs len = %d, want 1", got)
+	}
+	if s.RecentSyncs[0].MirrorType != "provider" {
+		t.Errorf("RecentSyncs[0].MirrorType = %q, want provider", s.RecentSyncs[0].MirrorType)
+	}
+}

--- a/internal/provider/datasource_stats.go
+++ b/internal/provider/datasource_stats.go
@@ -226,11 +226,11 @@ func (d *StatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 		Downloads:     types.Int64Value(stats.Downloads),
 	}
 
-	model.Modules = buildModulesObject(ctx, &stats.Modules, &resp.Diagnostics)
-	model.Providers = buildProvidersObject(ctx, &stats.Providers, &resp.Diagnostics)
-	model.ProviderMirrors = buildProviderMirrorsObject(ctx, &stats.ProviderMirrors, &resp.Diagnostics)
-	model.BinaryMirrors = buildBinaryMirrorsObject(ctx, &stats.BinaryMirrors, &resp.Diagnostics)
-	model.RecentSyncs = buildRecentSyncsList(ctx, stats.RecentSyncs, &resp.Diagnostics)
+	model.Modules = buildModulesObject(&stats.Modules, &resp.Diagnostics)
+	model.Providers = buildProvidersObject(&stats.Providers, &resp.Diagnostics)
+	model.ProviderMirrors = buildProviderMirrorsObject(&stats.ProviderMirrors, &resp.Diagnostics)
+	model.BinaryMirrors = buildBinaryMirrorsObject(&stats.BinaryMirrors, &resp.Diagnostics)
+	model.RecentSyncs = buildRecentSyncsList(stats.RecentSyncs, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -239,7 +239,7 @@ func (d *StatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
-func buildModulesObject(ctx context.Context, m *client.ModuleStats, diags *diag.Diagnostics) types.Object {
+func buildModulesObject(m *client.ModuleStats, diags *diag.Diagnostics) types.Object {
 	bySystemList := types.ListNull(types.ObjectType{AttrTypes: moduleSystemAttrTypes()})
 	if len(m.BySystem) > 0 {
 		elems := make([]attr.Value, 0, len(m.BySystem))
@@ -265,7 +265,7 @@ func buildModulesObject(ctx context.Context, m *client.ModuleStats, diags *diag.
 	return obj
 }
 
-func buildProvidersObject(ctx context.Context, p *client.ProviderStats, diags *diag.Diagnostics) types.Object {
+func buildProvidersObject(p *client.ProviderStats, diags *diag.Diagnostics) types.Object {
 	obj, d := types.ObjectValue(providerStatsAttrTypes(), map[string]attr.Value{
 		"total":             types.Int64Value(int64(p.Total)),
 		"total_versions":    types.Int64Value(int64(p.TotalVersions)),
@@ -279,7 +279,7 @@ func buildProvidersObject(ctx context.Context, p *client.ProviderStats, diags *d
 	return obj
 }
 
-func buildProviderMirrorsObject(ctx context.Context, p *client.ProviderMirrorStats, diags *diag.Diagnostics) types.Object {
+func buildProviderMirrorsObject(p *client.ProviderMirrorStats, diags *diag.Diagnostics) types.Object {
 	obj, d := types.ObjectValue(providerMirrorStatsAttrTypes(), map[string]attr.Value{
 		"total":   types.Int64Value(int64(p.Total)),
 		"healthy": types.Int64Value(int64(p.Healthy)),
@@ -289,7 +289,7 @@ func buildProviderMirrorsObject(ctx context.Context, p *client.ProviderMirrorSta
 	return obj
 }
 
-func buildBinaryMirrorsObject(ctx context.Context, b *client.BinaryMirrorStats, diags *diag.Diagnostics) types.Object {
+func buildBinaryMirrorsObject(b *client.BinaryMirrorStats, diags *diag.Diagnostics) types.Object {
 	byToolList := types.ListNull(types.ObjectType{AttrTypes: binaryToolAttrTypes()})
 	if len(b.ByTool) > 0 {
 		elems := make([]attr.Value, 0, len(b.ByTool))
@@ -318,7 +318,7 @@ func buildBinaryMirrorsObject(ctx context.Context, b *client.BinaryMirrorStats, 
 	return obj
 }
 
-func buildRecentSyncsList(ctx context.Context, entries []client.RecentSyncEntry, diags *diag.Diagnostics) types.List {
+func buildRecentSyncsList(entries []client.RecentSyncEntry, diags *diag.Diagnostics) types.List {
 	if len(entries) == 0 {
 		return types.ListNull(types.ObjectType{AttrTypes: recentSyncAttrTypes()})
 	}

--- a/internal/provider/datasource_stats.go
+++ b/internal/provider/datasource_stats.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
@@ -16,13 +18,20 @@ type StatsDataSource struct {
 	client *client.Client
 }
 
+// StatsDataSourceModel mirrors backend admin.DashboardStats. The shape was
+// reworked alongside the v1 backend release: the previous flat counters
+// (total_modules, total_users, ...) were replaced with per-resource
+// sub-objects. See data source docs for migration notes.
 type StatsDataSourceModel struct {
-	TotalModules   types.Int64 `tfsdk:"total_modules"`
-	TotalProviders types.Int64 `tfsdk:"total_providers"`
-	TotalUsers     types.Int64 `tfsdk:"total_users"`
-	TotalOrgs      types.Int64 `tfsdk:"total_organizations"`
-	TotalMirrors   types.Int64 `tfsdk:"total_mirrors"`
-	TotalAPIKeys   types.Int64 `tfsdk:"total_api_keys"`
+	Users           types.Int64  `tfsdk:"users"`
+	Organizations   types.Int64  `tfsdk:"organizations"`
+	SCMProviders    types.Int64  `tfsdk:"scm_providers"`
+	Downloads       types.Int64  `tfsdk:"downloads"`
+	Modules         types.Object `tfsdk:"modules"`
+	Providers       types.Object `tfsdk:"providers"`
+	ProviderMirrors types.Object `tfsdk:"provider_mirrors"`
+	BinaryMirrors   types.Object `tfsdk:"binary_mirrors"`
+	RecentSyncs     types.List   `tfsdk:"recent_syncs"`
 }
 
 func NewStatsDataSource() datasource.DataSource {
@@ -33,16 +42,160 @@ func (d *StatsDataSource) Metadata(_ context.Context, req datasource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_stats"
 }
 
+func moduleSystemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"system": types.StringType,
+		"count":  types.Int64Type,
+	}
+}
+
+func binaryToolAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"tool":  types.StringType,
+		"count": types.Int64Type,
+	}
+}
+
+func moduleStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":     types.Int64Type,
+		"versions":  types.Int64Type,
+		"downloads": types.Int64Type,
+		"by_system": types.ListType{ElemType: types.ObjectType{AttrTypes: moduleSystemAttrTypes()}},
+	}
+}
+
+func providerStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":             types.Int64Type,
+		"total_versions":    types.Int64Type,
+		"manual":            types.Int64Type,
+		"manual_versions":   types.Int64Type,
+		"mirrored":          types.Int64Type,
+		"mirrored_versions": types.Int64Type,
+		"downloads":         types.Int64Type,
+	}
+}
+
+func providerMirrorStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":   types.Int64Type,
+		"healthy": types.Int64Type,
+		"failed":  types.Int64Type,
+	}
+}
+
+func binaryMirrorStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":     types.Int64Type,
+		"healthy":   types.Int64Type,
+		"failed":    types.Int64Type,
+		"syncing":   types.Int64Type,
+		"downloads": types.Int64Type,
+		"platforms": types.Int64Type,
+		"by_tool":   types.ListType{ElemType: types.ObjectType{AttrTypes: binaryToolAttrTypes()}},
+	}
+}
+
+func recentSyncAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"mirror_name":      types.StringType,
+		"mirror_type":      types.StringType,
+		"status":           types.StringType,
+		"triggered_by":     types.StringType,
+		"started_at":       types.StringType,
+		"completed_at":     types.StringType,
+		"versions_synced":  types.Int64Type,
+		"platforms_synced": types.Int64Type,
+	}
+}
+
 func (d *StatsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Reads dashboard statistics from the registry.",
+		Description: "Reads dashboard statistics from the registry. The shape mirrors the backend admin.DashboardStats response — the flat `total_*` counters from earlier provider versions are no longer present; use the nested `modules`, `providers`, `provider_mirrors`, and `binary_mirrors` blocks instead.",
 		Attributes: map[string]schema.Attribute{
-			"total_modules":       schema.Int64Attribute{Computed: true, Description: "Total number of modules."},
-			"total_providers":     schema.Int64Attribute{Computed: true, Description: "Total number of providers."},
-			"total_users":         schema.Int64Attribute{Computed: true, Description: "Total number of users."},
-			"total_organizations": schema.Int64Attribute{Computed: true, Description: "Total number of organizations."},
-			"total_mirrors":       schema.Int64Attribute{Computed: true, Description: "Total number of mirrors."},
-			"total_api_keys":      schema.Int64Attribute{Computed: true, Description: "Total number of API keys."},
+			"users":         schema.Int64Attribute{Computed: true, Description: "Total number of users."},
+			"organizations": schema.Int64Attribute{Computed: true, Description: "Total number of organizations."},
+			"scm_providers": schema.Int64Attribute{Computed: true, Description: "Total number of SCM provider integrations."},
+			"downloads":     schema.Int64Attribute{Computed: true, Description: "Aggregate download count across all artifacts."},
+			"modules": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Module counters.",
+				Attributes: map[string]schema.Attribute{
+					"total":     schema.Int64Attribute{Computed: true, Description: "Total module records."},
+					"versions":  schema.Int64Attribute{Computed: true, Description: "Total module versions across all modules."},
+					"downloads": schema.Int64Attribute{Computed: true, Description: "Aggregate module download count."},
+					"by_system": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Per-system breakdown.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"system": schema.StringAttribute{Computed: true},
+								"count":  schema.Int64Attribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"providers": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Provider counters, split between manually published and mirror-synced records.",
+				Attributes: map[string]schema.Attribute{
+					"total":             schema.Int64Attribute{Computed: true},
+					"total_versions":    schema.Int64Attribute{Computed: true},
+					"manual":            schema.Int64Attribute{Computed: true, Description: "Providers published directly to this registry."},
+					"manual_versions":   schema.Int64Attribute{Computed: true},
+					"mirrored":          schema.Int64Attribute{Computed: true, Description: "Providers synced from upstream registries."},
+					"mirrored_versions": schema.Int64Attribute{Computed: true},
+					"downloads":         schema.Int64Attribute{Computed: true},
+				},
+			},
+			"provider_mirrors": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Provider-mirror configuration health.",
+				Attributes: map[string]schema.Attribute{
+					"total":   schema.Int64Attribute{Computed: true},
+					"healthy": schema.Int64Attribute{Computed: true, Description: "Last sync succeeded or never run but enabled."},
+					"failed":  schema.Int64Attribute{Computed: true, Description: "Last sync failed."},
+				},
+			},
+			"binary_mirrors": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Terraform/OpenTofu binary mirror configuration health.",
+				Attributes: map[string]schema.Attribute{
+					"total":     schema.Int64Attribute{Computed: true},
+					"healthy":   schema.Int64Attribute{Computed: true},
+					"failed":    schema.Int64Attribute{Computed: true},
+					"syncing":   schema.Int64Attribute{Computed: true, Description: "Sync currently running."},
+					"downloads": schema.Int64Attribute{Computed: true},
+					"platforms": schema.Int64Attribute{Computed: true, Description: "Total synced platform binaries."},
+					"by_tool": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"tool":  schema.StringAttribute{Computed: true},
+								"count": schema.Int64Attribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"recent_syncs": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Recent mirror sync runs (provider + binary), most recent first.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"mirror_name":      schema.StringAttribute{Computed: true},
+						"mirror_type":      schema.StringAttribute{Computed: true, Description: `"binary" or "provider".`},
+						"status":           schema.StringAttribute{Computed: true},
+						"triggered_by":     schema.StringAttribute{Computed: true},
+						"started_at":       schema.StringAttribute{Computed: true},
+						"completed_at":     schema.StringAttribute{Computed: true},
+						"versions_synced":  schema.Int64Attribute{Computed: true},
+						"platforms_synced": schema.Int64Attribute{Computed: true},
+					},
+				},
+			},
 		},
 	}
 }
@@ -66,12 +219,125 @@ func (d *StatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, StatsDataSourceModel{
-		TotalModules:   types.Int64Value(int64(stats.TotalModules)),
-		TotalProviders: types.Int64Value(int64(stats.TotalProviders)),
-		TotalUsers:     types.Int64Value(int64(stats.TotalUsers)),
-		TotalOrgs:      types.Int64Value(int64(stats.TotalOrgs)),
-		TotalMirrors:   types.Int64Value(int64(stats.TotalMirrors)),
-		TotalAPIKeys:   types.Int64Value(int64(stats.TotalAPIKeys)),
-	})...)
+	model := StatsDataSourceModel{
+		Users:         types.Int64Value(int64(stats.Users)),
+		Organizations: types.Int64Value(int64(stats.Organizations)),
+		SCMProviders:  types.Int64Value(int64(stats.SCMProviders)),
+		Downloads:     types.Int64Value(stats.Downloads),
+	}
+
+	model.Modules = buildModulesObject(ctx, &stats.Modules, &resp.Diagnostics)
+	model.Providers = buildProvidersObject(ctx, &stats.Providers, &resp.Diagnostics)
+	model.ProviderMirrors = buildProviderMirrorsObject(ctx, &stats.ProviderMirrors, &resp.Diagnostics)
+	model.BinaryMirrors = buildBinaryMirrorsObject(ctx, &stats.BinaryMirrors, &resp.Diagnostics)
+	model.RecentSyncs = buildRecentSyncsList(ctx, stats.RecentSyncs, &resp.Diagnostics)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func buildModulesObject(ctx context.Context, m *client.ModuleStats, diags *diag.Diagnostics) types.Object {
+	bySystemList := types.ListNull(types.ObjectType{AttrTypes: moduleSystemAttrTypes()})
+	if len(m.BySystem) > 0 {
+		elems := make([]attr.Value, 0, len(m.BySystem))
+		for _, e := range m.BySystem {
+			obj, d := types.ObjectValue(moduleSystemAttrTypes(), map[string]attr.Value{
+				"system": types.StringValue(e.System),
+				"count":  types.Int64Value(int64(e.Count)),
+			})
+			diags.Append(d...)
+			elems = append(elems, obj)
+		}
+		l, d := types.ListValue(types.ObjectType{AttrTypes: moduleSystemAttrTypes()}, elems)
+		diags.Append(d...)
+		bySystemList = l
+	}
+	obj, d := types.ObjectValue(moduleStatsAttrTypes(), map[string]attr.Value{
+		"total":     types.Int64Value(int64(m.Total)),
+		"versions":  types.Int64Value(int64(m.Versions)),
+		"downloads": types.Int64Value(m.Downloads),
+		"by_system": bySystemList,
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildProvidersObject(ctx context.Context, p *client.ProviderStats, diags *diag.Diagnostics) types.Object {
+	obj, d := types.ObjectValue(providerStatsAttrTypes(), map[string]attr.Value{
+		"total":             types.Int64Value(int64(p.Total)),
+		"total_versions":    types.Int64Value(int64(p.TotalVersions)),
+		"manual":            types.Int64Value(int64(p.Manual)),
+		"manual_versions":   types.Int64Value(int64(p.ManualVersions)),
+		"mirrored":          types.Int64Value(int64(p.Mirrored)),
+		"mirrored_versions": types.Int64Value(int64(p.MirroredVersions)),
+		"downloads":         types.Int64Value(p.Downloads),
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildProviderMirrorsObject(ctx context.Context, p *client.ProviderMirrorStats, diags *diag.Diagnostics) types.Object {
+	obj, d := types.ObjectValue(providerMirrorStatsAttrTypes(), map[string]attr.Value{
+		"total":   types.Int64Value(int64(p.Total)),
+		"healthy": types.Int64Value(int64(p.Healthy)),
+		"failed":  types.Int64Value(int64(p.Failed)),
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildBinaryMirrorsObject(ctx context.Context, b *client.BinaryMirrorStats, diags *diag.Diagnostics) types.Object {
+	byToolList := types.ListNull(types.ObjectType{AttrTypes: binaryToolAttrTypes()})
+	if len(b.ByTool) > 0 {
+		elems := make([]attr.Value, 0, len(b.ByTool))
+		for _, e := range b.ByTool {
+			obj, d := types.ObjectValue(binaryToolAttrTypes(), map[string]attr.Value{
+				"tool":  types.StringValue(e.Tool),
+				"count": types.Int64Value(int64(e.Count)),
+			})
+			diags.Append(d...)
+			elems = append(elems, obj)
+		}
+		l, d := types.ListValue(types.ObjectType{AttrTypes: binaryToolAttrTypes()}, elems)
+		diags.Append(d...)
+		byToolList = l
+	}
+	obj, d := types.ObjectValue(binaryMirrorStatsAttrTypes(), map[string]attr.Value{
+		"total":     types.Int64Value(int64(b.Total)),
+		"healthy":   types.Int64Value(int64(b.Healthy)),
+		"failed":    types.Int64Value(int64(b.Failed)),
+		"syncing":   types.Int64Value(int64(b.Syncing)),
+		"downloads": types.Int64Value(b.Downloads),
+		"platforms": types.Int64Value(int64(b.Platforms)),
+		"by_tool":   byToolList,
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildRecentSyncsList(ctx context.Context, entries []client.RecentSyncEntry, diags *diag.Diagnostics) types.List {
+	if len(entries) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: recentSyncAttrTypes()})
+	}
+	elems := make([]attr.Value, 0, len(entries))
+	for _, e := range entries {
+		obj, d := types.ObjectValue(recentSyncAttrTypes(), map[string]attr.Value{
+			"mirror_name":      types.StringValue(e.MirrorName),
+			"mirror_type":      types.StringValue(e.MirrorType),
+			"status":           types.StringValue(e.Status),
+			"triggered_by":     types.StringValue(e.TriggeredBy),
+			"started_at":       types.StringValue(e.StartedAt),
+			"completed_at":     types.StringValue(e.CompletedAt),
+			"versions_synced":  types.Int64Value(int64(e.VersionsSynced)),
+			"platforms_synced": types.Int64Value(int64(e.PlatformsSynced)),
+		})
+		diags.Append(d...)
+		elems = append(elems, obj)
+	}
+	l, d := types.ListValue(types.ObjectType{AttrTypes: recentSyncAttrTypes()}, elems)
+	diags.Append(d...)
+	return l
 }

--- a/internal/provider/datasource_stats_test.go
+++ b/internal/provider/datasource_stats_test.go
@@ -13,10 +13,13 @@ func TestAccDataStats_basic(t *testing.T) {
 			{
 				Config: testAccProviderConfig() + `data "registry_stats" "dashboard" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_modules"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_providers"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_organizations"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_users"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "users"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "organizations"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "scm_providers"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "modules.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "providers.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "provider_mirrors.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "binary_mirrors.total"),
 				),
 			},
 		},


### PR DESCRIPTION
Closes #7

## Summary

The backend's `admin.DashboardStats` response replaced the flat `total_*` counters with per-resource sub-objects sometime before the provider's first release. The provider's `Stats` struct still expected the flat shape, so **every counter on `data.registry_stats` has been returning zero against any v1-era backend**.

### Breaking change

Anyone using the existing fields needs to migrate:

| Old (always 0)        | New                                                      |
|-----------------------|----------------------------------------------------------|
| `total_modules`       | `modules.total`                                          |
| `total_providers`     | `providers.total`                                        |
| `total_users`         | `users`                                                  |
| `total_organizations` | `organizations`                                          |
| `total_mirrors`       | `provider_mirrors.total` + `binary_mirrors.total`        |
| `total_api_keys`      | removed — backend does not expose this counter           |

### New attributes

Top-level scalars: `users`, `organizations`, `scm_providers`, `downloads`.

Nested objects:

- `modules { total, versions, downloads, by_system[] }`
- `providers { total, total_versions, manual, manual_versions, mirrored, mirrored_versions, downloads }`
- `provider_mirrors { total, healthy, failed }`
- `binary_mirrors { total, healthy, failed, syncing, downloads, platforms, by_tool[] }`
- `recent_syncs[]` — recent mirror sync runs across both mirror types

The example HCL is refreshed; the generated `docs/data-sources/stats.md` will need a `make docs` run before merge.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/client/...` — new round-trip test passes
- [x] `go test ./internal/provider/...` — existing non-acceptance tests pass
- [ ] Acceptance test (CI): verify nested attributes are populated against the test backend
- [ ] Run `make docs` to regenerate the stats data-source doc

## Changelog
- fix!: `data.registry_stats` reshaped to match backend `admin.DashboardStats` (was returning zeros against backend ≥ v0.x)