### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] - 2026-05-01
+
+This release realigns the provider with backend `terraform-registry-backend` v1.0.0
+(the backend was at ~v0.5 when v0.1.0 was cut). Several fields were silently
+dropping data or sending unintended writes against the v1 backend; those are
+fixed here.
+
+### Breaking Changes
+
+- `data.registry_stats` reshaped to match backend `admin.DashboardStats`. The flat `total_*` counters (`total_modules`, `total_providers`, `total_users`, `total_organizations`, `total_mirrors`, `total_api_keys`) were always returning zero against backend ≥ v0.x and have been replaced with nested objects. Migration table:
+
+  | Old (always 0)        | New                                               |
+  |-----------------------|---------------------------------------------------|
+  | `total_modules`       | `modules.total`                                   |
+  | `total_providers`     | `providers.total`                                 |
+  | `total_users`         | `users`                                           |
+  | `total_organizations` | `organizations`                                   |
+  | `total_mirrors`       | `provider_mirrors.total` + `binary_mirrors.total` |
+  | `total_api_keys`      | removed (backend does not expose this counter)    |
+
+  New nested attributes also expose `modules.{versions, downloads, by_system}`, full provider breakdown (manual vs. mirrored), mirror health, binary mirror platforms, and a `recent_syncs` ledger.
+
+- `registry_scm_provider` removed the phantom `oauth_status` attribute (the backend does not and never did expose this field — it was always `null`). Use the new `is_active` attribute, plus `organization_id`, `tenant_id`, `client_id`, and `webhook_secret`, to manage SCM integrations.
+
+### Fixed
+
+- `registry_storage_config` no longer shows perpetual diff on the `active` attribute. The backend renamed the response field from `active` to `is_active` before this provider's first release; the JSON tag has been updated to match. (#6)
+- `registry_mirror` and `registry_terraform_mirror` updates no longer overwrite `enabled`, `sync_interval_hours`, `gpg_verify`, or `stable_only` with zero values when those attributes are unchanged. The client request structs now use pointer fields so omitted attributes leave the existing value unchanged on the backend. (#8)
+- `registry_scm_provider` updates no longer overwrite unrelated fields with zero values (same root cause as #8). (#9)
+
+### Added
+
+- `registry_scm_provider` exposes `is_active`, `organization_id`, `tenant_id`, `client_id`, and `webhook_secret`. The phantom `oauth_status` field is removed (see breaking changes). (#9)
+- `registry_module_scm_link` adds `repository_path` (default `/`, for monorepo layouts) and `auto_publish_enabled` (default `false`, to opt into auto-publish on tag push). The read-side response now also surfaces the persisted `module_path`. (#10)
+- `registry_approval_request` exposes 8 new computed attributes: `organization_id`, `requested_by`, `requested_by_name`, `reviewer_name`, `reviewed_at`, `expires_at`, `auto_approved`, and `mirror_name`. (#11)
+
+### Tests
+
+- New client unit tests round-trip representative backend response payloads to guard against future drift on storage configs, mirrors, terraform mirrors, SCM providers, module SCM links, approval requests, and dashboard stats.
+
+---
+
 ## [0.1.1] - 2026-03-21
 
 ### Changed

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ HOSTNAME     = registry.terraform.io
 NAMESPACE    = terraform-registry
 NAME         = registry
 BINARY       = terraform-provider-${NAME}
-VERSION      = 0.1.0
+VERSION      = 0.2.0
 OS_ARCH      = $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build

--- a/examples/data-sources/registry_stats/data-source.tf
+++ b/examples/data-sources/registry_stats/data-source.tf
@@ -1,9 +1,21 @@
 data "registry_stats" "dashboard" {}
 
 output "total_modules" {
-  value = data.registry_stats.dashboard.total_modules
+  value = data.registry_stats.dashboard.modules.total
 }
 
 output "total_providers" {
-  value = data.registry_stats.dashboard.total_providers
+  value = data.registry_stats.dashboard.providers.total
+}
+
+output "total_users" {
+  value = data.registry_stats.dashboard.users
+}
+
+output "manual_provider_versions" {
+  value = data.registry_stats.dashboard.providers.manual_versions
+}
+
+output "binary_mirrors_healthy" {
+  value = data.registry_stats.dashboard.binary_mirrors.healthy
 }

--- a/internal/client/approval_requests_test.go
+++ b/internal/client/approval_requests_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestApprovalRequest_DecodesV1Fields covers the field expansion in #11 —
+// backend's MirrorApprovalRequest now returns organization_id, requested_by,
+// reviewed_at, expires_at, plus joined requested_by_name / reviewed_by_name /
+// mirror_name fields, none of which the previous client struct knew about.
+func TestApprovalRequest_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"mirror_config_id": "22222222-2222-2222-2222-222222222222",
+		"organization_id": "33333333-3333-3333-3333-333333333333",
+		"requested_by": "44444444-4444-4444-4444-444444444444",
+		"provider_namespace": "hashicorp",
+		"provider_name": "aws",
+		"reason": "needed for prod",
+		"status": "approved",
+		"reviewed_by": "55555555-5555-5555-5555-555555555555",
+		"reviewed_at": "2026-04-30T01:00:00Z",
+		"review_notes": "ok",
+		"auto_approved": false,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T01:00:00Z",
+		"expires_at": "2027-04-30T00:00:00Z",
+		"requested_by_name": "Alice",
+		"reviewed_by_name": "Bob",
+		"mirror_name": "hashicorp-prod"
+	}`)
+
+	var ar ApprovalRequest
+	if err := json.Unmarshal(body, &ar); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ar.OrganizationID == nil || *ar.OrganizationID != "33333333-3333-3333-3333-333333333333" {
+		t.Errorf("OrganizationID = %v, want UUID pointer", ar.OrganizationID)
+	}
+	if ar.RequestedBy == nil || *ar.RequestedBy != "44444444-4444-4444-4444-444444444444" {
+		t.Errorf("RequestedBy = %v", ar.RequestedBy)
+	}
+	if ar.ReviewedAt == nil || *ar.ReviewedAt != "2026-04-30T01:00:00Z" {
+		t.Errorf("ReviewedAt = %v", ar.ReviewedAt)
+	}
+	if ar.ExpiresAt == nil || *ar.ExpiresAt != "2027-04-30T00:00:00Z" {
+		t.Errorf("ExpiresAt = %v", ar.ExpiresAt)
+	}
+	if ar.RequestedByName != "Alice" {
+		t.Errorf("RequestedByName = %q", ar.RequestedByName)
+	}
+	if ar.ReviewedByName != "Bob" {
+		t.Errorf("ReviewedByName = %q", ar.ReviewedByName)
+	}
+	if ar.MirrorName != "hashicorp-prod" {
+		t.Errorf("MirrorName = %q", ar.MirrorName)
+	}
+}

--- a/internal/client/mirrors_test.go
+++ b/internal/client/mirrors_test.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestUpdateMirrorRequest_OmitsUnsetFields guards against the silent zero-value
+// PUT bug fixed in #8: backend treats omitted fields as "leave unchanged" but
+// the previous Go struct used plain bool/int, so missing optionals shipped as
+// `enabled: false` and `sync_interval_hours: 0`.
+func TestUpdateMirrorRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateMirrorRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wire := string(body)
+
+	// Must contain only what was set.
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	// Must NOT contain unset optional scalars — the fix for #8 is that these
+	// get omitted entirely rather than shipped as zero values.
+	for _, k := range []string{
+		`"enabled"`,
+		`"sync_interval_hours"`,
+		`"upstream_registry_url"`,
+		`"organization_id"`,
+		`"description"`,
+		`"version_filter"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}
+
+// TestUpdateTerraformMirrorRequest_OmitsUnsetFields covers the same guarantee
+// for the Terraform/OpenTofu binary mirror update request.
+func TestUpdateTerraformMirrorRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateTerraformMirrorRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	for _, k := range []string{
+		`"enabled"`,
+		`"sync_interval_hours"`,
+		`"gpg_verify"`,
+		`"stable_only"`,
+		`"tool"`,
+		`"upstream_url"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}
+
+// TestCreateMirrorRequest_RequiredFieldsPresent confirms required scalars
+// (which are not pointers) still ship even when other fields are unset.
+func TestCreateMirrorRequest_RequiredFieldsPresent(t *testing.T) {
+	req := CreateMirrorRequest{
+		Name:                "test",
+		UpstreamRegistryURL: "https://registry.example.com",
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"test"`) {
+		t.Errorf("required name missing: %s", wire)
+	}
+	if !strings.Contains(wire, `"upstream_registry_url":"https://registry.example.com"`) {
+		t.Errorf("required upstream URL missing: %s", wire)
+	}
+	// Optional pointer scalars omitted.
+	if strings.Contains(wire, `"enabled"`) {
+		t.Errorf("unset enabled should be omitted: %s", wire)
+	}
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -569,12 +569,81 @@ type AuditLog struct {
 	CreatedAt      string                 `json:"created_at"`
 }
 
-// Stats represents dashboard statistics.
+// Stats mirrors backend admin.DashboardStats. The shape was reworked
+// alongside the v1 backend release: counters are now grouped under
+// per-resource sub-objects with separate totals for versions, downloads,
+// and (for providers) manual vs. mirrored counts. The previous flat
+// counters (total_modules, total_users, ...) are no longer returned.
 type Stats struct {
-	TotalModules   int `json:"total_modules"`
-	TotalProviders int `json:"total_providers"`
-	TotalUsers     int `json:"total_users"`
-	TotalOrgs      int `json:"total_organizations"`
-	TotalMirrors   int `json:"total_mirrors"`
-	TotalAPIKeys   int `json:"total_api_keys"`
+	Modules         ModuleStats         `json:"modules"`
+	Providers       ProviderStats       `json:"providers"`
+	ProviderMirrors ProviderMirrorStats `json:"provider_mirrors"`
+	BinaryMirrors   BinaryMirrorStats   `json:"binary_mirrors"`
+	Users           int                 `json:"users"`
+	Organizations   int                 `json:"organizations"`
+	SCMProviders    int                 `json:"scm_providers"`
+	Downloads       int64               `json:"downloads"`
+	RecentSyncs     []RecentSyncEntry   `json:"recent_syncs"`
+}
+
+// ModuleStats is the modules sub-object of dashboard stats.
+type ModuleStats struct {
+	Total     int                `json:"total"`
+	Versions  int                `json:"versions"`
+	Downloads int64              `json:"downloads"`
+	BySystem  []ModuleSystemStat `json:"by_system,omitempty"`
+}
+
+// ModuleSystemStat is one entry in the modules.by_system breakdown.
+type ModuleSystemStat struct {
+	System string `json:"system"`
+	Count  int    `json:"count"`
+}
+
+// ProviderStats is the providers sub-object of dashboard stats.
+type ProviderStats struct {
+	Total            int   `json:"total"`
+	TotalVersions    int   `json:"total_versions"`
+	Manual           int   `json:"manual"`
+	ManualVersions   int   `json:"manual_versions"`
+	Mirrored         int   `json:"mirrored"`
+	MirroredVersions int   `json:"mirrored_versions"`
+	Downloads        int64 `json:"downloads"`
+}
+
+// ProviderMirrorStats is the provider_mirrors sub-object.
+type ProviderMirrorStats struct {
+	Total   int `json:"total"`
+	Healthy int `json:"healthy"`
+	Failed  int `json:"failed"`
+}
+
+// BinaryMirrorStats is the binary_mirrors (Terraform/OpenTofu) sub-object.
+type BinaryMirrorStats struct {
+	Total     int              `json:"total"`
+	Healthy   int              `json:"healthy"`
+	Failed    int              `json:"failed"`
+	Syncing   int              `json:"syncing"`
+	Downloads int64            `json:"downloads"`
+	Platforms int              `json:"platforms"`
+	ByTool    []BinaryToolStat `json:"by_tool,omitempty"`
+}
+
+// BinaryToolStat is one entry in binary_mirrors.by_tool.
+type BinaryToolStat struct {
+	Tool  string `json:"tool"`
+	Count int    `json:"count"`
+}
+
+// RecentSyncEntry is one row of the recent_syncs ledger across all mirror
+// types (provider mirrors + binary mirrors).
+type RecentSyncEntry struct {
+	MirrorName      string `json:"mirror_name"`
+	MirrorType      string `json:"mirror_type"` // "binary" | "provider"
+	Status          string `json:"status"`
+	TriggeredBy     string `json:"triggered_by"`
+	StartedAt       string `json:"started_at"`
+	CompletedAt     string `json:"completed_at,omitempty"`
+	VersionsSynced  int    `json:"versions_synced"`
+	PlatformsSynced int    `json:"platforms_synced"`
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -255,6 +255,11 @@ type Mirror struct {
 }
 
 // CreateMirrorRequest is the payload for creating a mirror.
+//
+// Optional scalar fields use pointers so the wire payload omits them entirely
+// when the caller has nothing to set, matching the backend's
+// CreateMirrorConfigRequest semantics in
+// backend/internal/db/models/mirror.go.
 type CreateMirrorRequest struct {
 	Name                string   `json:"name"`
 	Description         *string  `json:"description,omitempty"`
@@ -264,22 +269,28 @@ type CreateMirrorRequest struct {
 	ProviderFilter      []string `json:"provider_filter,omitempty"`
 	VersionFilter       *string  `json:"version_filter,omitempty"`
 	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	SyncIntervalHours   int      `json:"sync_interval_hours"`
+	Enabled             *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // UpdateMirrorRequest is the payload for updating a mirror.
+//
+// All fields are pointers; only fields the caller explicitly populates are
+// sent on the wire. This matches the backend's UpdateMirrorConfigRequest,
+// where omitted fields leave the existing value unchanged. Sending plain
+// bool/int zero values would silently disable the mirror or reset its sync
+// interval to zero.
 type UpdateMirrorRequest struct {
-	Name                string   `json:"name"`
+	Name                *string  `json:"name,omitempty"`
 	Description         *string  `json:"description,omitempty"`
-	UpstreamRegistryURL string   `json:"upstream_registry_url"`
+	UpstreamRegistryURL *string  `json:"upstream_registry_url,omitempty"`
 	OrganizationID      *string  `json:"organization_id,omitempty"`
 	NamespaceFilter     []string `json:"namespace_filter,omitempty"`
 	ProviderFilter      []string `json:"provider_filter,omitempty"`
 	VersionFilter       *string  `json:"version_filter,omitempty"`
 	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	SyncIntervalHours   int      `json:"sync_interval_hours"`
+	Enabled             *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // TerraformMirror represents a Terraform binary mirror configuration.
@@ -303,31 +314,40 @@ type TerraformMirror struct {
 }
 
 // CreateTerraformMirrorRequest is the payload for creating a Terraform mirror.
+//
+// Optional scalars use pointers so the wire payload omits them when the caller
+// has nothing to set; the backend then applies defaults. See
+// backend/internal/db/models/terraform_mirror.go.
 type CreateTerraformMirrorRequest struct {
 	Name              string   `json:"name"`
 	Description       *string  `json:"description,omitempty"`
 	Tool              string   `json:"tool"`
-	Enabled           bool     `json:"enabled"`
+	Enabled           *bool    `json:"enabled,omitempty"`
 	UpstreamURL       string   `json:"upstream_url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
-	GPGVerify         bool     `json:"gpg_verify"`
-	StableOnly        bool     `json:"stable_only"`
-	SyncIntervalHours int      `json:"sync_interval_hours"`
+	GPGVerify         *bool    `json:"gpg_verify,omitempty"`
+	StableOnly        *bool    `json:"stable_only,omitempty"`
+	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // UpdateTerraformMirrorRequest is the payload for updating a Terraform mirror.
+//
+// All fields are pointers; omitted fields leave the existing value unchanged
+// to match backend UpdateTerraformMirrorConfigRequest semantics. Sending plain
+// bool/int zero values would silently disable the mirror or skip GPG
+// verification.
 type UpdateTerraformMirrorRequest struct {
-	Name              string   `json:"name"`
+	Name              *string  `json:"name,omitempty"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              string   `json:"tool"`
-	Enabled           bool     `json:"enabled"`
-	UpstreamURL       string   `json:"upstream_url"`
+	Tool              *string  `json:"tool,omitempty"`
+	Enabled           *bool    `json:"enabled,omitempty"`
+	UpstreamURL       *string  `json:"upstream_url,omitempty"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
-	GPGVerify         bool     `json:"gpg_verify"`
-	StableOnly        bool     `json:"stable_only"`
-	SyncIntervalHours int      `json:"sync_interval_hours"`
+	GPGVerify         *bool    `json:"gpg_verify,omitempty"`
+	StableOnly        *bool    `json:"stable_only,omitempty"`
+	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
 // StorageConfig represents a storage backend configuration.

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -517,18 +517,33 @@ type UpdatePolicyRequest struct {
 }
 
 // ApprovalRequest represents a mirror approval request.
+//
+// Mirrors backend's MirrorApprovalRequest in
+// backend/internal/db/models/mirror_approval.go. The OrganizationID,
+// RequestedBy, ReviewedAt, ExpiresAt, RequestedByName, ReviewedByName,
+// and MirrorName fields are populated by the backend on read; none of
+// them are accepted on the create payload.
 type ApprovalRequest struct {
 	ID                string  `json:"id"`
 	MirrorConfigID    string  `json:"mirror_config_id"`
+	OrganizationID    *string `json:"organization_id,omitempty"`
+	RequestedBy       *string `json:"requested_by,omitempty"`
 	ProviderNamespace string  `json:"provider_namespace"`
 	ProviderName      *string `json:"provider_name,omitempty"`
 	Reason            string  `json:"reason,omitempty"`
 	Status            string  `json:"status"`
 	ReviewedBy        *string `json:"reviewed_by,omitempty"`
+	ReviewedAt        *string `json:"reviewed_at,omitempty"`
 	ReviewNotes       *string `json:"review_notes,omitempty"`
 	AutoApproved      bool    `json:"auto_approved"`
 	CreatedAt         string  `json:"created_at"`
 	UpdatedAt         string  `json:"updated_at"`
+	ExpiresAt         *string `json:"expires_at,omitempty"`
+
+	// Joined fields (populated server-side via LEFT JOIN; never written).
+	RequestedByName string `json:"requested_by_name,omitempty"`
+	ReviewedByName  string `json:"reviewed_by_name,omitempty"`
+	MirrorName      string `json:"mirror_name,omitempty"`
 }
 
 // CreateApprovalRequestRequest is the payload for creating an approval request.

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -334,7 +334,7 @@ type UpdateTerraformMirrorRequest struct {
 type StorageConfig struct {
 	ID          string `json:"id"`
 	BackendType string `json:"backend_type"`
-	Active      bool   `json:"active"`
+	IsActive    bool   `json:"is_active"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 	// Individual backend fields returned by API (credentials redacted)

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -175,31 +175,46 @@ type UpdateProviderRecordRequest struct {
 }
 
 // SCMProvider represents an SCM (source control) integration.
+//
+// Mirrors the backend scm.SCMProvider type. ClientID is exposed on the
+// response (not the secret); WebhookSecret is never returned.
 type SCMProvider struct {
-	ID           string  `json:"id"`
-	Name         string  `json:"name"`
-	ProviderType string  `json:"provider_type"`
-	BaseURL      *string `json:"base_url,omitempty"`
-	OAuthStatus  *string `json:"oauth_status,omitempty"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
+	ID             string  `json:"id"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+	Name           string  `json:"name"`
+	ProviderType   string  `json:"provider_type"`
+	BaseURL        *string `json:"base_url,omitempty"`
+	TenantID       *string `json:"tenant_id,omitempty"`
+	ClientID       string  `json:"client_id,omitempty"`
+	IsActive       bool    `json:"is_active"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
 }
 
 // CreateSCMProviderRequest is the payload for creating an SCM provider.
 type CreateSCMProviderRequest struct {
-	Name          string  `json:"name"`
-	ProviderType  string  `json:"provider_type"`
-	BaseURL       *string `json:"base_url,omitempty"`
-	ClientID      string  `json:"client_id,omitempty"`
-	ClientSecret  string  `json:"client_secret,omitempty"`
-	WebhookSecret string  `json:"webhook_secret,omitempty"`
-	TenantID      *string `json:"tenant_id,omitempty"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+	Name           string  `json:"name"`
+	ProviderType   string  `json:"provider_type"`
+	BaseURL        *string `json:"base_url,omitempty"`
+	TenantID       *string `json:"tenant_id,omitempty"`
+	ClientID       string  `json:"client_id,omitempty"`
+	ClientSecret   string  `json:"client_secret,omitempty"`
+	WebhookSecret  string  `json:"webhook_secret,omitempty"`
 }
 
 // UpdateSCMProviderRequest is the payload for updating an SCM provider.
+//
+// All fields are pointers; omitted fields leave the existing value
+// unchanged on the backend.
 type UpdateSCMProviderRequest struct {
-	Name    string  `json:"name"`
-	BaseURL *string `json:"base_url,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	BaseURL       *string `json:"base_url,omitempty"`
+	TenantID      *string `json:"tenant_id,omitempty"`
+	ClientID      *string `json:"client_id,omitempty"`
+	ClientSecret  *string `json:"client_secret,omitempty"`
+	WebhookSecret *string `json:"webhook_secret,omitempty"`
+	IsActive      *bool   `json:"is_active,omitempty"`
 }
 
 // ModuleSCMLink represents a link between a module and an SCM repository.

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -218,6 +218,12 @@ type UpdateSCMProviderRequest struct {
 }
 
 // ModuleSCMLink represents a link between a module and an SCM repository.
+//
+// JSON field naming on read intentionally differs from the create/update
+// request bodies: the response carries module_path / auto_publish_enabled
+// while the request bodies use repository_path / auto_publish_enabled.
+// See backend/internal/scm/types.go (response) and
+// backend/internal/api/modules/scm_linking.go (request).
 type ModuleSCMLink struct {
 	ID              string `json:"id"`
 	ModuleID        string `json:"module_id"`
@@ -225,18 +231,26 @@ type ModuleSCMLink struct {
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	ModulePath      string `json:"module_path"`
 	TagPattern      string `json:"tag_pattern"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 	CreatedAt       string `json:"created_at"`
 	UpdatedAt       string `json:"updated_at"`
 }
 
 // CreateModuleSCMLinkRequest is the payload for creating a module SCM link.
+//
+// Note the request field is repository_path, not module_path; the backend
+// renames it on persist. See LinkSCMRequest in
+// backend/internal/api/modules/scm_linking.go.
 type CreateModuleSCMLinkRequest struct {
 	SCMProviderID   string `json:"provider_id"`
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	RepositoryPath  string `json:"repository_path,omitempty"`
 	TagPattern      string `json:"tag_pattern,omitempty"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 }
 
 // UpdateModuleSCMLinkRequest is the payload for updating a module SCM link.
@@ -245,7 +259,9 @@ type UpdateModuleSCMLinkRequest struct {
 	RepositoryOwner string `json:"repository_owner"`
 	RepositoryName  string `json:"repository_name"`
 	DefaultBranch   string `json:"default_branch"`
+	RepositoryPath  string `json:"repository_path,omitempty"`
 	TagPattern      string `json:"tag_pattern,omitempty"`
+	AutoPublish     bool   `json:"auto_publish_enabled"`
 }
 
 // Mirror represents a provider mirror configuration.

--- a/internal/client/module_scm_links_test.go
+++ b/internal/client/module_scm_links_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestModuleSCMLink_DecodesV1Fields covers the fix in #10 — backend's response
+// model carries module_path and auto_publish_enabled, which the previous
+// provider client struct was missing entirely.
+func TestModuleSCMLink_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"module_id": "22222222-2222-2222-2222-222222222222",
+		"scm_provider_id": "33333333-3333-3333-3333-333333333333",
+		"repository_owner": "acme",
+		"repository_name": "vpc",
+		"default_branch": "main",
+		"module_path": "modules/vpc",
+		"tag_pattern": "v*",
+		"auto_publish_enabled": true,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var l ModuleSCMLink
+	if err := json.Unmarshal(body, &l); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if l.ModulePath != "modules/vpc" {
+		t.Errorf("ModulePath = %q, want modules/vpc (json tag must be module_path)", l.ModulePath)
+	}
+	if !l.AutoPublish {
+		t.Errorf("AutoPublish = false, want true (json tag must be auto_publish_enabled)")
+	}
+}
+
+// TestCreateModuleSCMLinkRequest_UsesRepositoryPath asserts the asymmetric
+// naming on the request side: backend's LinkSCMRequest accepts
+// repository_path (the request renames module_path on persist) and
+// auto_publish_enabled.
+func TestCreateModuleSCMLinkRequest_UsesRepositoryPath(t *testing.T) {
+	req := CreateModuleSCMLinkRequest{
+		SCMProviderID:   "p",
+		RepositoryOwner: "acme",
+		RepositoryName:  "vpc",
+		DefaultBranch:   "main",
+		RepositoryPath:  "modules/vpc",
+		AutoPublish:     true,
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"repository_path":"modules/vpc"`) {
+		t.Errorf("missing repository_path on the wire: %s", wire)
+	}
+	if !strings.Contains(wire, `"auto_publish_enabled":true`) {
+		t.Errorf("missing auto_publish_enabled on the wire: %s", wire)
+	}
+	if strings.Contains(wire, `"module_path"`) {
+		t.Errorf("request body should not use module_path (response-side name): %s", wire)
+	}
+}

--- a/internal/client/scm_providers_test.go
+++ b/internal/client/scm_providers_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSCMProvider_DecodesV1Fields guards against the model drift fixed in #9:
+// backend's scm.SCMProvider now exposes organization_id, is_active, tenant_id,
+// and client_id, while the previous provider model expected a phantom
+// oauth_status field that does not exist in the backend.
+func TestSCMProvider_DecodesV1Fields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"provider_type": "github",
+		"name": "main-github",
+		"base_url": "https://github.example.com",
+		"client_id": "abc123",
+		"is_active": true,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var p SCMProvider
+	if err := json.Unmarshal(body, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !p.IsActive {
+		t.Errorf("IsActive = false, want true")
+	}
+	if p.OrganizationID == nil || *p.OrganizationID != "22222222-2222-2222-2222-222222222222" {
+		t.Errorf("OrganizationID = %v, want pointer to UUID", p.OrganizationID)
+	}
+	if p.ClientID != "abc123" {
+		t.Errorf("ClientID = %q, want abc123", p.ClientID)
+	}
+}
+
+// TestUpdateSCMProviderRequest_OmitsUnsetFields confirms the pointer-typed
+// update request omits unset optional fields from the wire payload, matching
+// the backend semantics where missing fields are left unchanged.
+func TestUpdateSCMProviderRequest_OmitsUnsetFields(t *testing.T) {
+	name := "renamed"
+	req := UpdateSCMProviderRequest{Name: &name}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	wire := string(body)
+
+	if !strings.Contains(wire, `"name":"renamed"`) {
+		t.Errorf("payload missing name: %s", wire)
+	}
+
+	for _, k := range []string{
+		`"base_url"`,
+		`"tenant_id"`,
+		`"client_id"`,
+		`"client_secret"`,
+		`"webhook_secret"`,
+		`"is_active"`,
+	} {
+		if strings.Contains(wire, k) {
+			t.Errorf("unset field %s leaked into wire payload: %s", k, wire)
+		}
+	}
+}

--- a/internal/client/stats_test.go
+++ b/internal/client/stats_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStats_DecodesDashboardShape covers the major reshape in #7 — the
+// backend's admin.DashboardStats response replaced the flat total_* counters
+// with per-resource sub-objects. The previous client.Stats struct read every
+// field as zero against the v1 backend.
+func TestStats_DecodesDashboardShape(t *testing.T) {
+	body := []byte(`{
+		"users": 42,
+		"organizations": 7,
+		"scm_providers": 3,
+		"downloads": 12345,
+		"modules": {
+			"total": 100,
+			"versions": 350,
+			"downloads": 5000,
+			"by_system": [
+				{"system": "aws", "count": 60},
+				{"system": "azurerm", "count": 40}
+			]
+		},
+		"providers": {
+			"total": 25,
+			"total_versions": 120,
+			"manual": 5,
+			"manual_versions": 30,
+			"mirrored": 20,
+			"mirrored_versions": 90,
+			"downloads": 7000
+		},
+		"provider_mirrors": {
+			"total": 4,
+			"healthy": 3,
+			"failed": 1
+		},
+		"binary_mirrors": {
+			"total": 2,
+			"healthy": 2,
+			"failed": 0,
+			"syncing": 0,
+			"downloads": 345,
+			"platforms": 18,
+			"by_tool": [
+				{"tool": "terraform", "count": 1},
+				{"tool": "opentofu", "count": 1}
+			]
+		},
+		"recent_syncs": [
+			{
+				"mirror_name": "hashicorp",
+				"mirror_type": "provider",
+				"status": "success",
+				"triggered_by": "scheduler",
+				"started_at": "2026-04-30T00:00:00Z",
+				"completed_at": "2026-04-30T00:05:00Z",
+				"versions_synced": 12,
+				"platforms_synced": 0
+			}
+		]
+	}`)
+
+	var s Stats
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if s.Users != 42 {
+		t.Errorf("Users = %d, want 42", s.Users)
+	}
+	if s.Modules.Total != 100 {
+		t.Errorf("Modules.Total = %d, want 100", s.Modules.Total)
+	}
+	if s.Modules.Downloads != 5000 {
+		t.Errorf("Modules.Downloads = %d, want 5000", s.Modules.Downloads)
+	}
+	if got := len(s.Modules.BySystem); got != 2 {
+		t.Errorf("Modules.BySystem len = %d, want 2", got)
+	}
+	if s.Providers.Manual != 5 || s.Providers.Mirrored != 20 {
+		t.Errorf("Providers manual/mirrored = %d/%d, want 5/20",
+			s.Providers.Manual, s.Providers.Mirrored)
+	}
+	if s.ProviderMirrors.Healthy != 3 {
+		t.Errorf("ProviderMirrors.Healthy = %d, want 3", s.ProviderMirrors.Healthy)
+	}
+	if s.BinaryMirrors.Platforms != 18 {
+		t.Errorf("BinaryMirrors.Platforms = %d, want 18", s.BinaryMirrors.Platforms)
+	}
+	if got := len(s.RecentSyncs); got != 1 {
+		t.Fatalf("RecentSyncs len = %d, want 1", got)
+	}
+	if s.RecentSyncs[0].MirrorType != "provider" {
+		t.Errorf("RecentSyncs[0].MirrorType = %q, want provider", s.RecentSyncs[0].MirrorType)
+	}
+}

--- a/internal/client/storage_configs_test.go
+++ b/internal/client/storage_configs_test.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStorageConfig_DecodesIsActive guards against the JSON-tag drift fixed
+// in #6: backend renamed "active" to "is_active" before the provider's first
+// release, leaving the resource showing perpetual diff on the active attribute.
+func TestStorageConfig_DecodesIsActive(t *testing.T) {
+	// Sample response shape taken from backend StorageConfigResponse
+	// (backend/internal/db/models/storage_config.go).
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"backend_type": "s3",
+		"is_active": true,
+		"s3_region": "us-east-1",
+		"s3_bucket": "example",
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var sc StorageConfig
+	if err := json.Unmarshal(body, &sc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !sc.IsActive {
+		t.Errorf("IsActive = false, want true (JSON tag must be is_active)")
+	}
+	if sc.BackendType != "s3" {
+		t.Errorf("BackendType = %q, want s3", sc.BackendType)
+	}
+}

--- a/internal/provider/datasource_scm_providers.go
+++ b/internal/provider/datasource_scm_providers.go
@@ -21,13 +21,16 @@ type SCMProvidersDataSourceModel struct {
 }
 
 type SCMProviderDSItem struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Type        types.String `tfsdk:"type"`
-	BaseURL     types.String `tfsdk:"base_url"`
-	OAuthStatus types.String `tfsdk:"oauth_status"`
-	CreatedAt   types.String `tfsdk:"created_at"`
-	UpdatedAt   types.String `tfsdk:"updated_at"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Name           types.String `tfsdk:"name"`
+	Type           types.String `tfsdk:"type"`
+	BaseURL        types.String `tfsdk:"base_url"`
+	TenantID       types.String `tfsdk:"tenant_id"`
+	ClientID       types.String `tfsdk:"client_id"`
+	IsActive       types.Bool   `tfsdk:"is_active"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewSCMProvidersDataSource() datasource.DataSource {
@@ -47,13 +50,16 @@ func (d *SCMProvidersDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id":           schema.StringAttribute{Computed: true, Description: "UUID."},
-						"name":         schema.StringAttribute{Computed: true, Description: "Display name."},
-						"type":         schema.StringAttribute{Computed: true, Description: "SCM type."},
-						"base_url":     schema.StringAttribute{Computed: true, Description: "Base URL for self-hosted instances."},
-						"oauth_status": schema.StringAttribute{Computed: true, Description: "OAuth token status."},
-						"created_at":   schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-						"updated_at":   schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
+						"id":              schema.StringAttribute{Computed: true, Description: "UUID."},
+						"organization_id": schema.StringAttribute{Computed: true, Description: "Organization the integration is scoped to (null for global)."},
+						"name":            schema.StringAttribute{Computed: true, Description: "Display name."},
+						"type":            schema.StringAttribute{Computed: true, Description: "SCM type."},
+						"base_url":        schema.StringAttribute{Computed: true, Description: "Base URL for self-hosted instances."},
+						"tenant_id":       schema.StringAttribute{Computed: true, Description: "Azure DevOps tenant ID."},
+						"client_id":       schema.StringAttribute{Computed: true, Description: "OAuth client ID."},
+						"is_active":       schema.BoolAttribute{Computed: true, Description: "Whether the integration is enabled."},
+						"created_at":      schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
+						"updated_at":      schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
 				},
 			},
@@ -92,18 +98,29 @@ func (d *SCMProvidersDataSource) Read(ctx context.Context, req datasource.ReadRe
 			ID:        types.StringValue(s.ID),
 			Name:      types.StringValue(s.Name),
 			Type:      types.StringValue(s.ProviderType),
+			IsActive:  types.BoolValue(s.IsActive),
 			CreatedAt: types.StringValue(s.CreatedAt),
 			UpdatedAt: types.StringValue(s.UpdatedAt),
+		}
+		if s.OrganizationID != nil {
+			item.OrganizationID = types.StringValue(*s.OrganizationID)
+		} else {
+			item.OrganizationID = types.StringNull()
 		}
 		if s.BaseURL != nil {
 			item.BaseURL = types.StringValue(*s.BaseURL)
 		} else {
 			item.BaseURL = types.StringNull()
 		}
-		if s.OAuthStatus != nil {
-			item.OAuthStatus = types.StringValue(*s.OAuthStatus)
+		if s.TenantID != nil {
+			item.TenantID = types.StringValue(*s.TenantID)
 		} else {
-			item.OAuthStatus = types.StringNull()
+			item.TenantID = types.StringNull()
+		}
+		if s.ClientID != "" {
+			item.ClientID = types.StringValue(s.ClientID)
+		} else {
+			item.ClientID = types.StringNull()
 		}
 		items[i] = item
 	}

--- a/internal/provider/datasource_stats.go
+++ b/internal/provider/datasource_stats.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
@@ -16,13 +18,20 @@ type StatsDataSource struct {
 	client *client.Client
 }
 
+// StatsDataSourceModel mirrors backend admin.DashboardStats. The shape was
+// reworked alongside the v1 backend release: the previous flat counters
+// (total_modules, total_users, ...) were replaced with per-resource
+// sub-objects. See data source docs for migration notes.
 type StatsDataSourceModel struct {
-	TotalModules   types.Int64 `tfsdk:"total_modules"`
-	TotalProviders types.Int64 `tfsdk:"total_providers"`
-	TotalUsers     types.Int64 `tfsdk:"total_users"`
-	TotalOrgs      types.Int64 `tfsdk:"total_organizations"`
-	TotalMirrors   types.Int64 `tfsdk:"total_mirrors"`
-	TotalAPIKeys   types.Int64 `tfsdk:"total_api_keys"`
+	Users           types.Int64  `tfsdk:"users"`
+	Organizations   types.Int64  `tfsdk:"organizations"`
+	SCMProviders    types.Int64  `tfsdk:"scm_providers"`
+	Downloads       types.Int64  `tfsdk:"downloads"`
+	Modules         types.Object `tfsdk:"modules"`
+	Providers       types.Object `tfsdk:"providers"`
+	ProviderMirrors types.Object `tfsdk:"provider_mirrors"`
+	BinaryMirrors   types.Object `tfsdk:"binary_mirrors"`
+	RecentSyncs     types.List   `tfsdk:"recent_syncs"`
 }
 
 func NewStatsDataSource() datasource.DataSource {
@@ -33,16 +42,160 @@ func (d *StatsDataSource) Metadata(_ context.Context, req datasource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_stats"
 }
 
+func moduleSystemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"system": types.StringType,
+		"count":  types.Int64Type,
+	}
+}
+
+func binaryToolAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"tool":  types.StringType,
+		"count": types.Int64Type,
+	}
+}
+
+func moduleStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":     types.Int64Type,
+		"versions":  types.Int64Type,
+		"downloads": types.Int64Type,
+		"by_system": types.ListType{ElemType: types.ObjectType{AttrTypes: moduleSystemAttrTypes()}},
+	}
+}
+
+func providerStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":             types.Int64Type,
+		"total_versions":    types.Int64Type,
+		"manual":            types.Int64Type,
+		"manual_versions":   types.Int64Type,
+		"mirrored":          types.Int64Type,
+		"mirrored_versions": types.Int64Type,
+		"downloads":         types.Int64Type,
+	}
+}
+
+func providerMirrorStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":   types.Int64Type,
+		"healthy": types.Int64Type,
+		"failed":  types.Int64Type,
+	}
+}
+
+func binaryMirrorStatsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"total":     types.Int64Type,
+		"healthy":   types.Int64Type,
+		"failed":    types.Int64Type,
+		"syncing":   types.Int64Type,
+		"downloads": types.Int64Type,
+		"platforms": types.Int64Type,
+		"by_tool":   types.ListType{ElemType: types.ObjectType{AttrTypes: binaryToolAttrTypes()}},
+	}
+}
+
+func recentSyncAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"mirror_name":      types.StringType,
+		"mirror_type":      types.StringType,
+		"status":           types.StringType,
+		"triggered_by":     types.StringType,
+		"started_at":       types.StringType,
+		"completed_at":     types.StringType,
+		"versions_synced":  types.Int64Type,
+		"platforms_synced": types.Int64Type,
+	}
+}
+
 func (d *StatsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Reads dashboard statistics from the registry.",
+		Description: "Reads dashboard statistics from the registry. The shape mirrors the backend admin.DashboardStats response — the flat `total_*` counters from earlier provider versions are no longer present; use the nested `modules`, `providers`, `provider_mirrors`, and `binary_mirrors` blocks instead.",
 		Attributes: map[string]schema.Attribute{
-			"total_modules":       schema.Int64Attribute{Computed: true, Description: "Total number of modules."},
-			"total_providers":     schema.Int64Attribute{Computed: true, Description: "Total number of providers."},
-			"total_users":         schema.Int64Attribute{Computed: true, Description: "Total number of users."},
-			"total_organizations": schema.Int64Attribute{Computed: true, Description: "Total number of organizations."},
-			"total_mirrors":       schema.Int64Attribute{Computed: true, Description: "Total number of mirrors."},
-			"total_api_keys":      schema.Int64Attribute{Computed: true, Description: "Total number of API keys."},
+			"users":         schema.Int64Attribute{Computed: true, Description: "Total number of users."},
+			"organizations": schema.Int64Attribute{Computed: true, Description: "Total number of organizations."},
+			"scm_providers": schema.Int64Attribute{Computed: true, Description: "Total number of SCM provider integrations."},
+			"downloads":     schema.Int64Attribute{Computed: true, Description: "Aggregate download count across all artifacts."},
+			"modules": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Module counters.",
+				Attributes: map[string]schema.Attribute{
+					"total":     schema.Int64Attribute{Computed: true, Description: "Total module records."},
+					"versions":  schema.Int64Attribute{Computed: true, Description: "Total module versions across all modules."},
+					"downloads": schema.Int64Attribute{Computed: true, Description: "Aggregate module download count."},
+					"by_system": schema.ListNestedAttribute{
+						Computed:    true,
+						Description: "Per-system breakdown.",
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"system": schema.StringAttribute{Computed: true},
+								"count":  schema.Int64Attribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"providers": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Provider counters, split between manually published and mirror-synced records.",
+				Attributes: map[string]schema.Attribute{
+					"total":             schema.Int64Attribute{Computed: true},
+					"total_versions":    schema.Int64Attribute{Computed: true},
+					"manual":            schema.Int64Attribute{Computed: true, Description: "Providers published directly to this registry."},
+					"manual_versions":   schema.Int64Attribute{Computed: true},
+					"mirrored":          schema.Int64Attribute{Computed: true, Description: "Providers synced from upstream registries."},
+					"mirrored_versions": schema.Int64Attribute{Computed: true},
+					"downloads":         schema.Int64Attribute{Computed: true},
+				},
+			},
+			"provider_mirrors": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Provider-mirror configuration health.",
+				Attributes: map[string]schema.Attribute{
+					"total":   schema.Int64Attribute{Computed: true},
+					"healthy": schema.Int64Attribute{Computed: true, Description: "Last sync succeeded or never run but enabled."},
+					"failed":  schema.Int64Attribute{Computed: true, Description: "Last sync failed."},
+				},
+			},
+			"binary_mirrors": schema.SingleNestedAttribute{
+				Computed:    true,
+				Description: "Terraform/OpenTofu binary mirror configuration health.",
+				Attributes: map[string]schema.Attribute{
+					"total":     schema.Int64Attribute{Computed: true},
+					"healthy":   schema.Int64Attribute{Computed: true},
+					"failed":    schema.Int64Attribute{Computed: true},
+					"syncing":   schema.Int64Attribute{Computed: true, Description: "Sync currently running."},
+					"downloads": schema.Int64Attribute{Computed: true},
+					"platforms": schema.Int64Attribute{Computed: true, Description: "Total synced platform binaries."},
+					"by_tool": schema.ListNestedAttribute{
+						Computed: true,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"tool":  schema.StringAttribute{Computed: true},
+								"count": schema.Int64Attribute{Computed: true},
+							},
+						},
+					},
+				},
+			},
+			"recent_syncs": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Recent mirror sync runs (provider + binary), most recent first.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"mirror_name":      schema.StringAttribute{Computed: true},
+						"mirror_type":      schema.StringAttribute{Computed: true, Description: `"binary" or "provider".`},
+						"status":           schema.StringAttribute{Computed: true},
+						"triggered_by":     schema.StringAttribute{Computed: true},
+						"started_at":       schema.StringAttribute{Computed: true},
+						"completed_at":     schema.StringAttribute{Computed: true},
+						"versions_synced":  schema.Int64Attribute{Computed: true},
+						"platforms_synced": schema.Int64Attribute{Computed: true},
+					},
+				},
+			},
 		},
 	}
 }
@@ -66,12 +219,125 @@ func (d *StatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, re
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, StatsDataSourceModel{
-		TotalModules:   types.Int64Value(int64(stats.TotalModules)),
-		TotalProviders: types.Int64Value(int64(stats.TotalProviders)),
-		TotalUsers:     types.Int64Value(int64(stats.TotalUsers)),
-		TotalOrgs:      types.Int64Value(int64(stats.TotalOrgs)),
-		TotalMirrors:   types.Int64Value(int64(stats.TotalMirrors)),
-		TotalAPIKeys:   types.Int64Value(int64(stats.TotalAPIKeys)),
-	})...)
+	model := StatsDataSourceModel{
+		Users:         types.Int64Value(int64(stats.Users)),
+		Organizations: types.Int64Value(int64(stats.Organizations)),
+		SCMProviders:  types.Int64Value(int64(stats.SCMProviders)),
+		Downloads:     types.Int64Value(stats.Downloads),
+	}
+
+	model.Modules = buildModulesObject(&stats.Modules, &resp.Diagnostics)
+	model.Providers = buildProvidersObject(&stats.Providers, &resp.Diagnostics)
+	model.ProviderMirrors = buildProviderMirrorsObject(&stats.ProviderMirrors, &resp.Diagnostics)
+	model.BinaryMirrors = buildBinaryMirrorsObject(&stats.BinaryMirrors, &resp.Diagnostics)
+	model.RecentSyncs = buildRecentSyncsList(stats.RecentSyncs, &resp.Diagnostics)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func buildModulesObject(m *client.ModuleStats, diags *diag.Diagnostics) types.Object {
+	bySystemList := types.ListNull(types.ObjectType{AttrTypes: moduleSystemAttrTypes()})
+	if len(m.BySystem) > 0 {
+		elems := make([]attr.Value, 0, len(m.BySystem))
+		for _, e := range m.BySystem {
+			obj, d := types.ObjectValue(moduleSystemAttrTypes(), map[string]attr.Value{
+				"system": types.StringValue(e.System),
+				"count":  types.Int64Value(int64(e.Count)),
+			})
+			diags.Append(d...)
+			elems = append(elems, obj)
+		}
+		l, d := types.ListValue(types.ObjectType{AttrTypes: moduleSystemAttrTypes()}, elems)
+		diags.Append(d...)
+		bySystemList = l
+	}
+	obj, d := types.ObjectValue(moduleStatsAttrTypes(), map[string]attr.Value{
+		"total":     types.Int64Value(int64(m.Total)),
+		"versions":  types.Int64Value(int64(m.Versions)),
+		"downloads": types.Int64Value(m.Downloads),
+		"by_system": bySystemList,
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildProvidersObject(p *client.ProviderStats, diags *diag.Diagnostics) types.Object {
+	obj, d := types.ObjectValue(providerStatsAttrTypes(), map[string]attr.Value{
+		"total":             types.Int64Value(int64(p.Total)),
+		"total_versions":    types.Int64Value(int64(p.TotalVersions)),
+		"manual":            types.Int64Value(int64(p.Manual)),
+		"manual_versions":   types.Int64Value(int64(p.ManualVersions)),
+		"mirrored":          types.Int64Value(int64(p.Mirrored)),
+		"mirrored_versions": types.Int64Value(int64(p.MirroredVersions)),
+		"downloads":         types.Int64Value(p.Downloads),
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildProviderMirrorsObject(p *client.ProviderMirrorStats, diags *diag.Diagnostics) types.Object {
+	obj, d := types.ObjectValue(providerMirrorStatsAttrTypes(), map[string]attr.Value{
+		"total":   types.Int64Value(int64(p.Total)),
+		"healthy": types.Int64Value(int64(p.Healthy)),
+		"failed":  types.Int64Value(int64(p.Failed)),
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildBinaryMirrorsObject(b *client.BinaryMirrorStats, diags *diag.Diagnostics) types.Object {
+	byToolList := types.ListNull(types.ObjectType{AttrTypes: binaryToolAttrTypes()})
+	if len(b.ByTool) > 0 {
+		elems := make([]attr.Value, 0, len(b.ByTool))
+		for _, e := range b.ByTool {
+			obj, d := types.ObjectValue(binaryToolAttrTypes(), map[string]attr.Value{
+				"tool":  types.StringValue(e.Tool),
+				"count": types.Int64Value(int64(e.Count)),
+			})
+			diags.Append(d...)
+			elems = append(elems, obj)
+		}
+		l, d := types.ListValue(types.ObjectType{AttrTypes: binaryToolAttrTypes()}, elems)
+		diags.Append(d...)
+		byToolList = l
+	}
+	obj, d := types.ObjectValue(binaryMirrorStatsAttrTypes(), map[string]attr.Value{
+		"total":     types.Int64Value(int64(b.Total)),
+		"healthy":   types.Int64Value(int64(b.Healthy)),
+		"failed":    types.Int64Value(int64(b.Failed)),
+		"syncing":   types.Int64Value(int64(b.Syncing)),
+		"downloads": types.Int64Value(b.Downloads),
+		"platforms": types.Int64Value(int64(b.Platforms)),
+		"by_tool":   byToolList,
+	})
+	diags.Append(d...)
+	return obj
+}
+
+func buildRecentSyncsList(entries []client.RecentSyncEntry, diags *diag.Diagnostics) types.List {
+	if len(entries) == 0 {
+		return types.ListNull(types.ObjectType{AttrTypes: recentSyncAttrTypes()})
+	}
+	elems := make([]attr.Value, 0, len(entries))
+	for _, e := range entries {
+		obj, d := types.ObjectValue(recentSyncAttrTypes(), map[string]attr.Value{
+			"mirror_name":      types.StringValue(e.MirrorName),
+			"mirror_type":      types.StringValue(e.MirrorType),
+			"status":           types.StringValue(e.Status),
+			"triggered_by":     types.StringValue(e.TriggeredBy),
+			"started_at":       types.StringValue(e.StartedAt),
+			"completed_at":     types.StringValue(e.CompletedAt),
+			"versions_synced":  types.Int64Value(int64(e.VersionsSynced)),
+			"platforms_synced": types.Int64Value(int64(e.PlatformsSynced)),
+		})
+		diags.Append(d...)
+		elems = append(elems, obj)
+	}
+	l, d := types.ListValue(types.ObjectType{AttrTypes: recentSyncAttrTypes()}, elems)
+	diags.Append(d...)
+	return l
 }

--- a/internal/provider/datasource_stats_test.go
+++ b/internal/provider/datasource_stats_test.go
@@ -13,10 +13,13 @@ func TestAccDataStats_basic(t *testing.T) {
 			{
 				Config: testAccProviderConfig() + `data "registry_stats" "dashboard" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_modules"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_providers"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_organizations"),
-					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "total_users"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "users"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "organizations"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "scm_providers"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "modules.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "providers.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "provider_mirrors.total"),
+					resource.TestCheckResourceAttrSet("data.registry_stats.dashboard", "binary_mirrors.total"),
 				),
 			},
 		},

--- a/internal/provider/resource_approval_request.go
+++ b/internal/provider/resource_approval_request.go
@@ -22,12 +22,20 @@ type ApprovalRequestResource struct {
 type ApprovalRequestResourceModel struct {
 	ID                types.String `tfsdk:"id"`
 	MirrorID          types.String `tfsdk:"mirror_id"`
+	OrganizationID    types.String `tfsdk:"organization_id"`
 	ProviderNamespace types.String `tfsdk:"provider_namespace"`
 	ProviderName      types.String `tfsdk:"provider_name"`
 	Justification     types.String `tfsdk:"justification"`
 	ReviewStatus      types.String `tfsdk:"review_status"`
+	RequestedBy       types.String `tfsdk:"requested_by"`
+	RequestedByName   types.String `tfsdk:"requested_by_name"`
 	ReviewerID        types.String `tfsdk:"reviewer_id"`
+	ReviewerName      types.String `tfsdk:"reviewer_name"`
+	ReviewedAt        types.String `tfsdk:"reviewed_at"`
 	ReviewNote        types.String `tfsdk:"review_note"`
+	ExpiresAt         types.String `tfsdk:"expires_at"`
+	AutoApproved      types.Bool   `tfsdk:"auto_approved"`
+	MirrorName        types.String `tfsdk:"mirror_name"`
 	CreatedAt         types.String `tfsdk:"created_at"`
 	UpdatedAt         types.String `tfsdk:"updated_at"`
 }
@@ -81,16 +89,48 @@ func (r *ApprovalRequestResource) Schema(_ context.Context, _ resource.SchemaReq
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this request was scoped to (null for global).",
+				Computed:    true,
+			},
 			"review_status": schema.StringAttribute{
 				Description: "Current review status: pending, approved, or rejected.",
+				Computed:    true,
+			},
+			"requested_by": schema.StringAttribute{
+				Description: "UUID of the user who created the request.",
+				Computed:    true,
+			},
+			"requested_by_name": schema.StringAttribute{
+				Description: "Display name of the requesting user.",
 				Computed:    true,
 			},
 			"reviewer_id": schema.StringAttribute{
 				Description: "UUID of the reviewing user.",
 				Computed:    true,
 			},
+			"reviewer_name": schema.StringAttribute{
+				Description: "Display name of the reviewing user.",
+				Computed:    true,
+			},
+			"reviewed_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the request was reviewed.",
+				Computed:    true,
+			},
 			"review_note": schema.StringAttribute{
 				Description: "Note from the reviewer.",
+				Computed:    true,
+			},
+			"expires_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when an approved request expires; null if it does not expire.",
+				Computed:    true,
+			},
+			"auto_approved": schema.BoolAttribute{
+				Description: "True if the request was auto-approved by a matching policy.",
+				Computed:    true,
+			},
+			"mirror_name": schema.StringAttribute{
+				Description: "Name of the mirror this approval request applies to.",
 				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
@@ -200,6 +240,7 @@ func approvalRequestToModel(a *client.ApprovalRequest) ApprovalRequestResourceMo
 		ProviderNamespace: types.StringValue(a.ProviderNamespace),
 		Justification:     types.StringValue(a.Reason),
 		ReviewStatus:      types.StringValue(a.Status),
+		AutoApproved:      types.BoolValue(a.AutoApproved),
 		CreatedAt:         types.StringValue(normalizeTimestamp(a.CreatedAt)),
 		UpdatedAt:         types.StringValue(normalizeTimestamp(a.UpdatedAt)),
 	}
@@ -208,15 +249,50 @@ func approvalRequestToModel(a *client.ApprovalRequest) ApprovalRequestResourceMo
 	} else {
 		model.ProviderName = types.StringNull()
 	}
+	if a.OrganizationID != nil {
+		model.OrganizationID = types.StringValue(*a.OrganizationID)
+	} else {
+		model.OrganizationID = types.StringNull()
+	}
+	if a.RequestedBy != nil {
+		model.RequestedBy = types.StringValue(*a.RequestedBy)
+	} else {
+		model.RequestedBy = types.StringNull()
+	}
+	if a.RequestedByName != "" {
+		model.RequestedByName = types.StringValue(a.RequestedByName)
+	} else {
+		model.RequestedByName = types.StringNull()
+	}
 	if a.ReviewedBy != nil {
 		model.ReviewerID = types.StringValue(*a.ReviewedBy)
 	} else {
 		model.ReviewerID = types.StringNull()
 	}
+	if a.ReviewedByName != "" {
+		model.ReviewerName = types.StringValue(a.ReviewedByName)
+	} else {
+		model.ReviewerName = types.StringNull()
+	}
+	if a.ReviewedAt != nil {
+		model.ReviewedAt = types.StringValue(normalizeTimestamp(*a.ReviewedAt))
+	} else {
+		model.ReviewedAt = types.StringNull()
+	}
 	if a.ReviewNotes != nil {
 		model.ReviewNote = types.StringValue(*a.ReviewNotes)
 	} else {
 		model.ReviewNote = types.StringNull()
+	}
+	if a.ExpiresAt != nil {
+		model.ExpiresAt = types.StringValue(normalizeTimestamp(*a.ExpiresAt))
+	} else {
+		model.ExpiresAt = types.StringNull()
+	}
+	if a.MirrorName != "" {
+		model.MirrorName = types.StringValue(a.MirrorName)
+	} else {
+		model.MirrorName = types.StringNull()
 	}
 	return model
 }

--- a/internal/provider/resource_mirror.go
+++ b/internal/provider/resource_mirror.go
@@ -156,8 +156,14 @@ func (r *MirrorResource) Create(ctx context.Context, req resource.CreateRequest,
 	createReq := client.CreateMirrorRequest{
 		Name:                plan.Name.ValueString(),
 		UpstreamRegistryURL: plan.UpstreamRegistryURL.ValueString(),
-		Enabled:             plan.Enabled.ValueBool(),
-		SyncIntervalHours:   int(plan.SyncIntervalHours.ValueInt64()),
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		createReq.Enabled = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		createReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -220,11 +226,19 @@ func (r *MirrorResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	name := plan.Name.ValueString()
+	upstream := plan.UpstreamRegistryURL.ValueString()
 	updateReq := client.UpdateMirrorRequest{
-		Name:                plan.Name.ValueString(),
-		UpstreamRegistryURL: plan.UpstreamRegistryURL.ValueString(),
-		Enabled:             plan.Enabled.ValueBool(),
-		SyncIntervalHours:   int(plan.SyncIntervalHours.ValueInt64()),
+		Name:                &name,
+		UpstreamRegistryURL: &upstream,
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		updateReq.Enabled = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		updateReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()

--- a/internal/provider/resource_module_scm_link.go
+++ b/internal/provider/resource_module_scm_link.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -20,14 +22,16 @@ type ModuleSCMLinkResource struct {
 }
 
 type ModuleSCMLinkResourceModel struct {
-	ModuleID      types.String `tfsdk:"module_id"`
-	SCMProviderID types.String `tfsdk:"scm_provider_id"`
-	Owner         types.String `tfsdk:"owner"`
-	Repo          types.String `tfsdk:"repo"`
-	Branch        types.String `tfsdk:"branch"`
-	TagPattern    types.String `tfsdk:"tag_pattern"`
-	CreatedAt     types.String `tfsdk:"created_at"`
-	UpdatedAt     types.String `tfsdk:"updated_at"`
+	ModuleID       types.String `tfsdk:"module_id"`
+	SCMProviderID  types.String `tfsdk:"scm_provider_id"`
+	Owner          types.String `tfsdk:"owner"`
+	Repo           types.String `tfsdk:"repo"`
+	Branch         types.String `tfsdk:"branch"`
+	RepositoryPath types.String `tfsdk:"repository_path"`
+	TagPattern     types.String `tfsdk:"tag_pattern"`
+	AutoPublish    types.Bool   `tfsdk:"auto_publish_enabled"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewModuleSCMLinkResource() resource.Resource {
@@ -65,10 +69,22 @@ func (r *ModuleSCMLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Description: "Default branch to watch.",
 				Required:    true,
 			},
+			"repository_path": schema.StringAttribute{
+				Description: "Path within the repository where the module sources live. Defaults to '/' (repo root). Use this for monorepo layouts.",
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("/"),
+			},
 			"tag_pattern": schema.StringAttribute{
 				Description: "Optional glob pattern for version tags (e.g., 'v*').",
 				Optional:    true,
 				Computed:    true,
+			},
+			"auto_publish_enabled": schema.BoolAttribute{
+				Description: "Whether to automatically publish a new module version when a matching tag is pushed. Defaults to false.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the link was created.",
@@ -109,6 +125,10 @@ func (r *ModuleSCMLinkResource) Create(ctx context.Context, req resource.CreateR
 		RepositoryOwner: plan.Owner.ValueString(),
 		RepositoryName:  plan.Repo.ValueString(),
 		DefaultBranch:   plan.Branch.ValueString(),
+		AutoPublish:     plan.AutoPublish.ValueBool(),
+	}
+	if !plan.RepositoryPath.IsNull() && !plan.RepositoryPath.IsUnknown() {
+		createReq.RepositoryPath = plan.RepositoryPath.ValueString()
 	}
 	if !plan.TagPattern.IsNull() && !plan.TagPattern.IsUnknown() {
 		createReq.TagPattern = plan.TagPattern.ValueString()
@@ -155,6 +175,10 @@ func (r *ModuleSCMLinkResource) Update(ctx context.Context, req resource.UpdateR
 		RepositoryOwner: plan.Owner.ValueString(),
 		RepositoryName:  plan.Repo.ValueString(),
 		DefaultBranch:   plan.Branch.ValueString(),
+		AutoPublish:     plan.AutoPublish.ValueBool(),
+	}
+	if !plan.RepositoryPath.IsNull() && !plan.RepositoryPath.IsUnknown() {
+		updateReq.RepositoryPath = plan.RepositoryPath.ValueString()
 	}
 	if !plan.TagPattern.IsNull() && !plan.TagPattern.IsUnknown() {
 		updateReq.TagPattern = plan.TagPattern.ValueString()
@@ -192,13 +216,15 @@ func (r *ModuleSCMLinkResource) ImportState(ctx context.Context, req resource.Im
 
 func moduleSCMLinkToModel(l *client.ModuleSCMLink) ModuleSCMLinkResourceModel {
 	model := ModuleSCMLinkResourceModel{
-		ModuleID:      types.StringValue(l.ModuleID),
-		SCMProviderID: types.StringValue(l.SCMProviderID),
-		Owner:         types.StringValue(l.RepositoryOwner),
-		Repo:          types.StringValue(l.RepositoryName),
-		Branch:        types.StringValue(l.DefaultBranch),
-		CreatedAt:     types.StringValue(l.CreatedAt),
-		UpdatedAt:     types.StringValue(l.UpdatedAt),
+		ModuleID:       types.StringValue(l.ModuleID),
+		SCMProviderID:  types.StringValue(l.SCMProviderID),
+		Owner:          types.StringValue(l.RepositoryOwner),
+		Repo:           types.StringValue(l.RepositoryName),
+		Branch:         types.StringValue(l.DefaultBranch),
+		RepositoryPath: types.StringValue(l.ModulePath),
+		AutoPublish:    types.BoolValue(l.AutoPublish),
+		CreatedAt:      types.StringValue(l.CreatedAt),
+		UpdatedAt:      types.StringValue(l.UpdatedAt),
 	}
 	if l.TagPattern != "" {
 		model.TagPattern = types.StringValue(l.TagPattern)

--- a/internal/provider/resource_scm_provider.go
+++ b/internal/provider/resource_scm_provider.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,15 +22,18 @@ type SCMProviderResource struct {
 }
 
 type SCMProviderResourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	Type         types.String `tfsdk:"type"`
-	BaseURL      types.String `tfsdk:"base_url"`
-	ClientID     types.String `tfsdk:"client_id"`
-	ClientSecret types.String `tfsdk:"client_secret"`
-	OAuthStatus  types.String `tfsdk:"oauth_status"`
-	CreatedAt    types.String `tfsdk:"created_at"`
-	UpdatedAt    types.String `tfsdk:"updated_at"`
+	ID             types.String `tfsdk:"id"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Name           types.String `tfsdk:"name"`
+	Type           types.String `tfsdk:"type"`
+	BaseURL        types.String `tfsdk:"base_url"`
+	TenantID       types.String `tfsdk:"tenant_id"`
+	ClientID       types.String `tfsdk:"client_id"`
+	ClientSecret   types.String `tfsdk:"client_secret"`
+	WebhookSecret  types.String `tfsdk:"webhook_secret"`
+	IsActive       types.Bool   `tfsdk:"is_active"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewSCMProviderResource() resource.Resource {
@@ -50,6 +55,14 @@ func (r *SCMProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this SCM integration is scoped to. Omit for a global integration.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"name": schema.StringAttribute{
 				Description: "Display name for this SCM integration.",
 				Required:    true,
@@ -62,22 +75,38 @@ func (r *SCMProviderResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"base_url": schema.StringAttribute{
-				Description: "Base URL for self-hosted SCM instances (e.g., 'https://github.mycompany.com').",
+				Description: "Base URL for self-hosted SCM instances (e.g., 'https://github.mycompany.com'). Required for Bitbucket Data Center.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"tenant_id": schema.StringAttribute{
+				Description: "Tenant ID for Azure DevOps integrations.",
 				Optional:    true,
 				Computed:    true,
 			},
 			"client_id": schema.StringAttribute{
 				Description: "OAuth application client ID. Required for OAuth-based providers (github, gitlab, azure, bitbucket cloud). Not returned after creation.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"client_secret": schema.StringAttribute{
 				Description: "OAuth application client secret. Required for OAuth-based providers. Not returned after creation.",
 				Optional:    true,
 				Sensitive:   true,
 			},
-			"oauth_status": schema.StringAttribute{
-				Description: "Current OAuth token status.",
+			"webhook_secret": schema.StringAttribute{
+				Description: "Shared secret used to validate incoming webhook payloads. Not returned after creation.",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"is_active": schema.BoolAttribute{
+				Description: "Whether the SCM integration is enabled. Defaults to true.",
+				Optional:    true,
 				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the SCM provider was created.",
@@ -117,15 +146,26 @@ func (r *SCMProviderResource) Create(ctx context.Context, req resource.CreateReq
 		Name:         plan.Name.ValueString(),
 		ProviderType: plan.Type.ValueString(),
 	}
+	if !plan.OrganizationID.IsNull() && !plan.OrganizationID.IsUnknown() {
+		v := plan.OrganizationID.ValueString()
+		createReq.OrganizationID = &v
+	}
 	if !plan.BaseURL.IsNull() && !plan.BaseURL.IsUnknown() {
 		v := plan.BaseURL.ValueString()
 		createReq.BaseURL = &v
+	}
+	if !plan.TenantID.IsNull() && !plan.TenantID.IsUnknown() {
+		v := plan.TenantID.ValueString()
+		createReq.TenantID = &v
 	}
 	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
 		createReq.ClientID = plan.ClientID.ValueString()
 	}
 	if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() {
 		createReq.ClientSecret = plan.ClientSecret.ValueString()
+	}
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		createReq.WebhookSecret = plan.WebhookSecret.ValueString()
 	}
 
 	scm, err := r.client.CreateSCMProvider(ctx, createReq)
@@ -135,9 +175,10 @@ func (r *SCMProviderResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from plan — not returned by API
-	model.ClientID = plan.ClientID
+	// Preserve write-only credentials from plan — backend never returns the
+	// secret values after creation.
 	model.ClientSecret = plan.ClientSecret
+	model.WebhookSecret = plan.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -159,9 +200,9 @@ func (r *SCMProviderResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from state — not returned by API
-	model.ClientID = state.ClientID
+	// Preserve write-only secrets from state — not returned by API.
 	model.ClientSecret = state.ClientSecret
+	model.WebhookSecret = state.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -174,12 +215,33 @@ func (r *SCMProviderResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	name := plan.Name.ValueString()
 	updateReq := client.UpdateSCMProviderRequest{
-		Name: plan.Name.ValueString(),
+		Name: &name,
 	}
 	if !plan.BaseURL.IsNull() && !plan.BaseURL.IsUnknown() {
 		v := plan.BaseURL.ValueString()
 		updateReq.BaseURL = &v
+	}
+	if !plan.TenantID.IsNull() && !plan.TenantID.IsUnknown() {
+		v := plan.TenantID.ValueString()
+		updateReq.TenantID = &v
+	}
+	if !plan.ClientID.IsNull() && !plan.ClientID.IsUnknown() {
+		v := plan.ClientID.ValueString()
+		updateReq.ClientID = &v
+	}
+	if !plan.ClientSecret.IsNull() && !plan.ClientSecret.IsUnknown() {
+		v := plan.ClientSecret.ValueString()
+		updateReq.ClientSecret = &v
+	}
+	if !plan.WebhookSecret.IsNull() && !plan.WebhookSecret.IsUnknown() {
+		v := plan.WebhookSecret.ValueString()
+		updateReq.WebhookSecret = &v
+	}
+	if !plan.IsActive.IsNull() && !plan.IsActive.IsUnknown() {
+		v := plan.IsActive.ValueBool()
+		updateReq.IsActive = &v
 	}
 
 	scm, err := r.client.UpdateSCMProvider(ctx, plan.ID.ValueString(), updateReq)
@@ -189,9 +251,9 @@ func (r *SCMProviderResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	model := scmProviderToModel(scm)
-	// Preserve write-only credentials from plan (or fall back to state)
-	model.ClientID = plan.ClientID
+	// Preserve write-only secrets from plan — not returned by API.
 	model.ClientSecret = plan.ClientSecret
+	model.WebhookSecret = plan.WebhookSecret
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -214,9 +276,9 @@ func (r *SCMProviderResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 	model := scmProviderToModel(scm)
-	// Credentials are not recoverable on import
-	model.ClientID = types.StringNull()
+	// Secrets are never returned by the API and cannot be recovered on import.
 	model.ClientSecret = types.StringNull()
+	model.WebhookSecret = types.StringNull()
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }
 
@@ -225,18 +287,29 @@ func scmProviderToModel(s *client.SCMProvider) SCMProviderResourceModel {
 		ID:        types.StringValue(s.ID),
 		Name:      types.StringValue(s.Name),
 		Type:      types.StringValue(s.ProviderType),
+		IsActive:  types.BoolValue(s.IsActive),
 		CreatedAt: types.StringValue(normalizeTimestamp(s.CreatedAt)),
 		UpdatedAt: types.StringValue(normalizeTimestamp(s.UpdatedAt)),
+	}
+	if s.OrganizationID != nil {
+		model.OrganizationID = types.StringValue(*s.OrganizationID)
+	} else {
+		model.OrganizationID = types.StringNull()
 	}
 	if s.BaseURL != nil {
 		model.BaseURL = types.StringValue(*s.BaseURL)
 	} else {
 		model.BaseURL = types.StringNull()
 	}
-	if s.OAuthStatus != nil {
-		model.OAuthStatus = types.StringValue(*s.OAuthStatus)
+	if s.TenantID != nil {
+		model.TenantID = types.StringValue(*s.TenantID)
 	} else {
-		model.OAuthStatus = types.StringNull()
+		model.TenantID = types.StringNull()
+	}
+	if s.ClientID != "" {
+		model.ClientID = types.StringValue(s.ClientID)
+	} else {
+		model.ClientID = types.StringNull()
 	}
 	return model
 }

--- a/internal/provider/resource_storage_config.go
+++ b/internal/provider/resource_storage_config.go
@@ -126,7 +126,7 @@ func (r *StorageConfigResource) Create(ctx context.Context, req resource.CreateR
 			resp.Diagnostics.AddError("Error Activating Storage Config", err.Error())
 			return
 		}
-		sc.Active = true
+		sc.IsActive = true
 	}
 
 	model := storageConfigToModel(ctx, sc, configMap)
@@ -181,12 +181,12 @@ func (r *StorageConfigResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	if plan.Activate.ValueBool() && !sc.Active {
+	if plan.Activate.ValueBool() && !sc.IsActive {
 		if err := r.client.ActivateStorageConfig(ctx, sc.ID); err != nil {
 			resp.Diagnostics.AddError("Error Activating Storage Config", err.Error())
 			return
 		}
-		sc.Active = true
+		sc.IsActive = true
 	}
 
 	model := storageConfigToModel(ctx, sc, configMap)
@@ -315,7 +315,7 @@ func storageConfigToModel(ctx context.Context, sc *client.StorageConfig, preserv
 		ID:        types.StringValue(sc.ID),
 		Backend:   types.StringValue(sc.BackendType),
 		Config:    cfgValue,
-		Active:    types.BoolValue(sc.Active),
+		Active:    types.BoolValue(sc.IsActive),
 		CreatedAt: types.StringValue(normalizeTimestamp(sc.CreatedAt)),
 		UpdatedAt: types.StringValue(normalizeTimestamp(sc.UpdatedAt)),
 	}

--- a/internal/provider/resource_terraform_mirror.go
+++ b/internal/provider/resource_terraform_mirror.go
@@ -153,13 +153,25 @@ func (r *TerraformMirrorResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	createReq := client.CreateTerraformMirrorRequest{
-		Name:              plan.Name.ValueString(),
-		Tool:              plan.Tool.ValueString(),
-		Enabled:           plan.Enabled.ValueBool(),
-		UpstreamURL:       plan.UpstreamURL.ValueString(),
-		GPGVerify:         plan.GPGVerify.ValueBool(),
-		StableOnly:        plan.StableOnly.ValueBool(),
-		SyncIntervalHours: int(plan.SyncIntervalHours.ValueInt64()),
+		Name:        plan.Name.ValueString(),
+		Tool:        plan.Tool.ValueString(),
+		UpstreamURL: plan.UpstreamURL.ValueString(),
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		createReq.Enabled = &v
+	}
+	if !plan.GPGVerify.IsNull() && !plan.GPGVerify.IsUnknown() {
+		v := plan.GPGVerify.ValueBool()
+		createReq.GPGVerify = &v
+	}
+	if !plan.StableOnly.IsNull() && !plan.StableOnly.IsUnknown() {
+		v := plan.StableOnly.ValueBool()
+		createReq.StableOnly = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		createReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -212,14 +224,29 @@ func (r *TerraformMirrorResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
+	name := plan.Name.ValueString()
+	tool := plan.Tool.ValueString()
+	upstream := plan.UpstreamURL.ValueString()
 	updateReq := client.UpdateTerraformMirrorRequest{
-		Name:              plan.Name.ValueString(),
-		Tool:              plan.Tool.ValueString(),
-		Enabled:           plan.Enabled.ValueBool(),
-		UpstreamURL:       plan.UpstreamURL.ValueString(),
-		GPGVerify:         plan.GPGVerify.ValueBool(),
-		StableOnly:        plan.StableOnly.ValueBool(),
-		SyncIntervalHours: int(plan.SyncIntervalHours.ValueInt64()),
+		Name:        &name,
+		Tool:        &tool,
+		UpstreamURL: &upstream,
+	}
+	if !plan.Enabled.IsNull() && !plan.Enabled.IsUnknown() {
+		v := plan.Enabled.ValueBool()
+		updateReq.Enabled = &v
+	}
+	if !plan.GPGVerify.IsNull() && !plan.GPGVerify.IsUnknown() {
+		v := plan.GPGVerify.ValueBool()
+		updateReq.GPGVerify = &v
+	}
+	if !plan.StableOnly.IsNull() && !plan.StableOnly.IsUnknown() {
+		v := plan.StableOnly.ValueBool()
+		updateReq.StableOnly = &v
+	}
+	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
+		v := int(plan.SyncIntervalHours.ValueInt64())
+		updateReq.SyncIntervalHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()


### PR DESCRIPTION
Release v0.2.0 — realigns the provider with terraform-registry-backend v1.0.0.

## Highlights

- **Two breaking changes** (both because the previous shape was returning bad data, not new feature design):
  - `data.registry_stats` reshaped to nested objects matching the backend's `admin.DashboardStats`. Old `total_*` counters were always returning zero.
  - `registry_scm_provider.oauth_status` removed — the field never existed in the backend; it was always null.
- **Three latent data-loss bugs fixed** (`storage_config.active`, mirror update PUTs, SCM provider update PUTs).
- **Two resources gain new attributes**: `registry_module_scm_link` (`repository_path`, `auto_publish_enabled`) and `registry_approval_request` (8 new computed fields).

See `CHANGELOG.md` for the full migration guide.

## Merged PRs

- #6 / #35 — fix(client): decode storage config active flag as is_active
- #8 / #36 — fix(mirrors): omit unset optional fields from update PUT payloads
- #9 / #37 — fix!(scm-provider): align model with backend; remove phantom oauth_status
- #10 / #38 — fix(module-scm-link): add repository_path and auto_publish_enabled
- #11 / #39 — feat(approval-request): expose new backend fields
- #7 / #40 — fix!(stats): reshape registry_stats to match backend DashboardStats

## Notes

- Pre-existing CI issue: acceptance tests fail on every PR with `openpgp: key expired` from terraform-plugin-testing's Terraform CLI download. This is a HashiCorp upstream issue — Build, Lint, and Unit Tests all pass on every PR. Each PR was admin-merged after confirming the failure was unrelated.