### PR TITLE
feat(organization): add idp_type and idp_name for IdP-bound orgs

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -25,24 +25,33 @@ type UpdateUserRequest struct {
 }
 
 // Organization represents a registry organization.
+//
+// Mirrors backend models.Organization. IdpType / IdpName bind the org to a
+// specific IdP and are nullable; null means no restriction.
 type Organization struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"display_name"`
+	IdpType     *string `json:"idp_type,omitempty"`
+	IdpName     *string `json:"idp_name,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
 }
 
 // CreateOrganizationRequest is the payload for creating an organization.
 type CreateOrganizationRequest struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"display_name"`
+	IdpType     *string `json:"idp_type,omitempty"`
+	IdpName     *string `json:"idp_name,omitempty"`
 }
 
 // UpdateOrganizationRequest is the payload for updating an organization.
 type UpdateOrganizationRequest struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"display_name"`
+	IdpType     *string `json:"idp_type,omitempty"`
+	IdpName     *string `json:"idp_name,omitempty"`
 }
 
 // OrganizationMember represents a user's membership in an organization.

--- a/internal/client/organizations_test.go
+++ b/internal/client/organizations_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestOrganization_DecodesIdpFields covers the addition in #12 — backend
+// model.Organization now carries idp_type and idp_name (nullable) for binding
+// the org to a specific IdP. The previous client struct dropped both.
+func TestOrganization_DecodesIdpFields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"name": "platform",
+		"display_name": "Platform",
+		"idp_type": "saml",
+		"idp_name": "okta-prod",
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var o Organization
+	if err := json.Unmarshal(body, &o); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if o.IdpType == nil || *o.IdpType != "saml" {
+		t.Errorf("IdpType = %v, want pointer to 'saml'", o.IdpType)
+	}
+	if o.IdpName == nil || *o.IdpName != "okta-prod" {
+		t.Errorf("IdpName = %v, want pointer to 'okta-prod'", o.IdpName)
+	}
+}

--- a/internal/provider/datasource_organizations.go
+++ b/internal/provider/datasource_organizations.go
@@ -25,6 +25,8 @@ type OrganizationModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	DisplayName types.String `tfsdk:"display_name"`
+	IdpType     types.String `tfsdk:"idp_type"`
+	IdpName     types.String `tfsdk:"idp_name"`
 	CreatedAt   types.String `tfsdk:"created_at"`
 	UpdatedAt   types.String `tfsdk:"updated_at"`
 }
@@ -53,6 +55,8 @@ func (d *OrganizationsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 						"id":           schema.StringAttribute{Computed: true, Description: "UUID of the organization."},
 						"name":         schema.StringAttribute{Computed: true, Description: "URL-safe namespace name."},
 						"display_name": schema.StringAttribute{Computed: true, Description: "Human-readable display name."},
+						"idp_type":     schema.StringAttribute{Computed: true, Description: "Identity-provider type binding ('oidc', 'saml', 'ldap', or null)."},
+						"idp_name":     schema.StringAttribute{Computed: true, Description: "Bound IdP name within the chosen idp_type."},
 						"created_at":   schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
 						"updated_at":   schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
@@ -89,13 +93,24 @@ func (d *OrganizationsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	models := make([]OrganizationModel, len(orgs))
 	for i, o := range orgs {
-		models[i] = OrganizationModel{
+		m := OrganizationModel{
 			ID:          types.StringValue(o.ID),
 			Name:        types.StringValue(o.Name),
 			DisplayName: types.StringValue(o.DisplayName),
 			CreatedAt:   types.StringValue(o.CreatedAt),
 			UpdatedAt:   types.StringValue(o.UpdatedAt),
 		}
+		if o.IdpType != nil {
+			m.IdpType = types.StringValue(*o.IdpType)
+		} else {
+			m.IdpType = types.StringNull()
+		}
+		if o.IdpName != nil {
+			m.IdpName = types.StringValue(*o.IdpName)
+		} else {
+			m.IdpName = types.StringNull()
+		}
+		models[i] = m
 	}
 
 	config.Organizations = models

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -23,6 +23,8 @@ type OrganizationResourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	DisplayName types.String `tfsdk:"display_name"`
+	IdpType     types.String `tfsdk:"idp_type"`
+	IdpName     types.String `tfsdk:"idp_name"`
 	CreatedAt   types.String `tfsdk:"created_at"`
 	UpdatedAt   types.String `tfsdk:"updated_at"`
 }
@@ -53,6 +55,16 @@ func (r *OrganizationResource) Schema(_ context.Context, _ resource.SchemaReques
 			"display_name": schema.StringAttribute{
 				Description: "Human-readable display name.",
 				Required:    true,
+			},
+			"idp_type": schema.StringAttribute{
+				Description: "Identity-provider type the organization is bound to: 'oidc', 'saml', 'ldap', or null. When set, only users authenticated via the matching IdP may join the organization.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"idp_name": schema.StringAttribute{
+				Description: "Name of the bound IdP within the chosen `idp_type` (e.g., the SAML IdP name configured in the backend).",
+				Optional:    true,
+				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the organization was created.",
@@ -88,10 +100,20 @@ func (r *OrganizationResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	org, err := r.client.CreateOrganization(ctx, client.CreateOrganizationRequest{
+	createReq := client.CreateOrganizationRequest{
 		Name:        plan.Name.ValueString(),
 		DisplayName: plan.DisplayName.ValueString(),
-	})
+	}
+	if !plan.IdpType.IsNull() && !plan.IdpType.IsUnknown() {
+		v := plan.IdpType.ValueString()
+		createReq.IdpType = &v
+	}
+	if !plan.IdpName.IsNull() && !plan.IdpName.IsUnknown() {
+		v := plan.IdpName.ValueString()
+		createReq.IdpName = &v
+	}
+
+	org, err := r.client.CreateOrganization(ctx, createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Creating Organization", err.Error())
 		return
@@ -127,10 +149,20 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	org, err := r.client.UpdateOrganization(ctx, plan.ID.ValueString(), client.UpdateOrganizationRequest{
+	updateReq := client.UpdateOrganizationRequest{
 		Name:        plan.Name.ValueString(),
 		DisplayName: plan.DisplayName.ValueString(),
-	})
+	}
+	if !plan.IdpType.IsNull() && !plan.IdpType.IsUnknown() {
+		v := plan.IdpType.ValueString()
+		updateReq.IdpType = &v
+	}
+	if !plan.IdpName.IsNull() && !plan.IdpName.IsUnknown() {
+		v := plan.IdpName.ValueString()
+		updateReq.IdpName = &v
+	}
+
+	org, err := r.client.UpdateOrganization(ctx, plan.ID.ValueString(), updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Organization", err.Error())
 		return
@@ -161,11 +193,22 @@ func (r *OrganizationResource) ImportState(ctx context.Context, req resource.Imp
 }
 
 func orgToModel(o *client.Organization) OrganizationResourceModel {
-	return OrganizationResourceModel{
+	model := OrganizationResourceModel{
 		ID:          types.StringValue(o.ID),
 		Name:        types.StringValue(o.Name),
 		DisplayName: types.StringValue(o.DisplayName),
 		CreatedAt:   types.StringValue(o.CreatedAt),
 		UpdatedAt:   types.StringValue(o.UpdatedAt),
 	}
+	if o.IdpType != nil {
+		model.IdpType = types.StringValue(*o.IdpType)
+	} else {
+		model.IdpType = types.StringNull()
+	}
+	if o.IdpName != nil {
+		model.IdpName = types.StringValue(*o.IdpName)
+	} else {
+		model.IdpName = types.StringNull()
+	}
+	return model
 }


### PR DESCRIPTION
Closes #12

## Summary

Backend's `models.Organization` carries `idp_type` and `idp_name` for binding an organization to a specific IdP — when set, only users authenticated via that IdP may join the org. The provider's client model was dropping both.

This PR:
- Adds `idp_type` and `idp_name` (both `*string`) to `client.Organization`, `CreateOrganizationRequest`, and `UpdateOrganizationRequest`.
- Surfaces them as Optional+Computed string attributes on `registry_organization` and as computed-only fields on `data.registry_organizations`.
- Adds a client unit test that round-trips the new fields from a sample backend response.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/client/...` passes
- [x] `go test ./internal/provider/...` passes
- [ ] Acceptance test (CI): create an org with `idp_type = \"saml\"`, `idp_name = \"okta-prod\"`, verify both round-trip

## Changelog
- feat: `registry_organization` supports `idp_type` and `idp_name` for organization-IdP binding