### PR TITLE
feat(module): expose computed deprecation state

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -115,18 +115,28 @@ type UpdateAPIKeyRequest struct {
 }
 
 // Module represents a registry module record.
+//
+// Mirrors backend models.Module. The deprecation fields (Deprecated,
+// DeprecatedAt, DeprecationMessage, SuccessorModuleID) reflect module-level
+// deprecation set via POST /api/v1/modules/{ns}/{name}/{sys}/deprecate. They
+// are read-only here; managing the deprecation lifecycle is the job of a
+// dedicated registry_module_deprecation resource (tracked separately).
 type Module struct {
-	ID             string  `json:"id"`
-	OrganizationID string  `json:"organization_id"`
-	Namespace      string  `json:"namespace"`
-	Name           string  `json:"name"`
-	System         string  `json:"system"`
-	Description    *string `json:"description,omitempty"`
-	Source         *string `json:"source,omitempty"`
-	CreatedBy      *string `json:"created_by,omitempty"`
-	CreatedByName  *string `json:"created_by_name,omitempty"`
-	CreatedAt      string  `json:"created_at"`
-	UpdatedAt      string  `json:"updated_at"`
+	ID                 string  `json:"id"`
+	OrganizationID     string  `json:"organization_id"`
+	Namespace          string  `json:"namespace"`
+	Name               string  `json:"name"`
+	System             string  `json:"system"`
+	Description        *string `json:"description,omitempty"`
+	Source             *string `json:"source,omitempty"`
+	CreatedBy          *string `json:"created_by,omitempty"`
+	CreatedByName      *string `json:"created_by_name,omitempty"`
+	CreatedAt          string  `json:"created_at"`
+	UpdatedAt          string  `json:"updated_at"`
+	Deprecated         bool    `json:"deprecated"`
+	DeprecatedAt       *string `json:"deprecated_at,omitempty"`
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+	SuccessorModuleID  *string `json:"successor_module_id,omitempty"`
 }
 
 // CreateModuleRequest is the payload for creating a module record.

--- a/internal/client/modules_test.go
+++ b/internal/client/modules_test.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestModule_DecodesDeprecationFields covers the addition in #13 — backend
+// model.Module carries module-level deprecation state (deprecated, deprecated_at,
+// deprecation_message, successor_module_id) which the previous client struct
+// dropped silently.
+func TestModule_DecodesDeprecationFields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"organization_id": "22222222-2222-2222-2222-222222222222",
+		"namespace": "acme",
+		"name": "vpc",
+		"system": "aws",
+		"deprecated": true,
+		"deprecated_at": "2026-04-30T00:00:00Z",
+		"deprecation_message": "Use acme/networking/aws instead",
+		"successor_module_id": "33333333-3333-3333-3333-333333333333",
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var m Module
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !m.Deprecated {
+		t.Errorf("Deprecated = false, want true")
+	}
+	if m.DeprecatedAt == nil || *m.DeprecatedAt != "2026-04-30T00:00:00Z" {
+		t.Errorf("DeprecatedAt = %v", m.DeprecatedAt)
+	}
+	if m.DeprecationMessage == nil || *m.DeprecationMessage != "Use acme/networking/aws instead" {
+		t.Errorf("DeprecationMessage = %v", m.DeprecationMessage)
+	}
+	if m.SuccessorModuleID == nil || *m.SuccessorModuleID != "33333333-3333-3333-3333-333333333333" {
+		t.Errorf("SuccessorModuleID = %v", m.SuccessorModuleID)
+	}
+}

--- a/internal/provider/datasource_modules.go
+++ b/internal/provider/datasource_modules.go
@@ -23,15 +23,19 @@ type ModulesDataSourceModel struct {
 }
 
 type ModuleDSItem struct {
-	ID             types.String `tfsdk:"id"`
-	OrganizationID types.String `tfsdk:"organization_id"`
-	Namespace      types.String `tfsdk:"namespace"`
-	Name           types.String `tfsdk:"name"`
-	System         types.String `tfsdk:"system"`
-	Description    types.String `tfsdk:"description"`
-	Source         types.String `tfsdk:"source"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	UpdatedAt      types.String `tfsdk:"updated_at"`
+	ID                 types.String `tfsdk:"id"`
+	OrganizationID     types.String `tfsdk:"organization_id"`
+	Namespace          types.String `tfsdk:"namespace"`
+	Name               types.String `tfsdk:"name"`
+	System             types.String `tfsdk:"system"`
+	Description        types.String `tfsdk:"description"`
+	Source             types.String `tfsdk:"source"`
+	Deprecated         types.Bool   `tfsdk:"deprecated"`
+	DeprecatedAt       types.String `tfsdk:"deprecated_at"`
+	DeprecationMessage types.String `tfsdk:"deprecation_message"`
+	SuccessorModuleID  types.String `tfsdk:"successor_module_id"`
+	CreatedAt          types.String `tfsdk:"created_at"`
+	UpdatedAt          types.String `tfsdk:"updated_at"`
 }
 
 func NewModulesDataSource() datasource.DataSource {
@@ -59,15 +63,19 @@ func (d *ModulesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id":              schema.StringAttribute{Computed: true, Description: "UUID."},
-						"organization_id": schema.StringAttribute{Computed: true, Description: "Organization UUID."},
-						"namespace":       schema.StringAttribute{Computed: true, Description: "Module namespace."},
-						"name":            schema.StringAttribute{Computed: true, Description: "Module name."},
-						"system":          schema.StringAttribute{Computed: true, Description: "Provider system."},
-						"description":     schema.StringAttribute{Computed: true, Description: "Description."},
-						"source":          schema.StringAttribute{Computed: true, Description: "Source repository URL."},
-						"created_at":      schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-						"updated_at":      schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
+						"id":                  schema.StringAttribute{Computed: true, Description: "UUID."},
+						"organization_id":     schema.StringAttribute{Computed: true, Description: "Organization UUID."},
+						"namespace":           schema.StringAttribute{Computed: true, Description: "Module namespace."},
+						"name":                schema.StringAttribute{Computed: true, Description: "Module name."},
+						"system":              schema.StringAttribute{Computed: true, Description: "Provider system."},
+						"description":         schema.StringAttribute{Computed: true, Description: "Description."},
+						"source":              schema.StringAttribute{Computed: true, Description: "Source repository URL."},
+						"deprecated":          schema.BoolAttribute{Computed: true, Description: "Whether the module is deprecated."},
+						"deprecated_at":       schema.StringAttribute{Computed: true, Description: "Deprecation timestamp."},
+						"deprecation_message": schema.StringAttribute{Computed: true, Description: "Optional deprecation message."},
+						"successor_module_id": schema.StringAttribute{Computed: true, Description: "UUID of the successor module."},
+						"created_at":          schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
+						"updated_at":          schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
 				},
 			},
@@ -108,6 +116,7 @@ func (d *ModulesDataSource) Read(ctx context.Context, req datasource.ReadRequest
 			Namespace:      types.StringValue(m.Namespace),
 			Name:           types.StringValue(m.Name),
 			System:         types.StringValue(m.System),
+			Deprecated:     types.BoolValue(m.Deprecated),
 			CreatedAt:      types.StringValue(m.CreatedAt),
 			UpdatedAt:      types.StringValue(m.UpdatedAt),
 		}
@@ -120,6 +129,21 @@ func (d *ModulesDataSource) Read(ctx context.Context, req datasource.ReadRequest
 			item.Source = types.StringValue(*m.Source)
 		} else {
 			item.Source = types.StringNull()
+		}
+		if m.DeprecatedAt != nil {
+			item.DeprecatedAt = types.StringValue(*m.DeprecatedAt)
+		} else {
+			item.DeprecatedAt = types.StringNull()
+		}
+		if m.DeprecationMessage != nil {
+			item.DeprecationMessage = types.StringValue(*m.DeprecationMessage)
+		} else {
+			item.DeprecationMessage = types.StringNull()
+		}
+		if m.SuccessorModuleID != nil {
+			item.SuccessorModuleID = types.StringValue(*m.SuccessorModuleID)
+		} else {
+			item.SuccessorModuleID = types.StringNull()
 		}
 		items[i] = item
 	}

--- a/internal/provider/resource_module.go
+++ b/internal/provider/resource_module.go
@@ -20,16 +20,20 @@ type ModuleResource struct {
 }
 
 type ModuleResourceModel struct {
-	ID             types.String `tfsdk:"id"`
-	OrganizationID types.String `tfsdk:"organization_id"`
-	Namespace      types.String `tfsdk:"namespace"`
-	Name           types.String `tfsdk:"name"`
-	System         types.String `tfsdk:"system"`
-	Description    types.String `tfsdk:"description"`
-	Source         types.String `tfsdk:"source"`
-	CreatedBy      types.String `tfsdk:"created_by"`
-	CreatedAt      types.String `tfsdk:"created_at"`
-	UpdatedAt      types.String `tfsdk:"updated_at"`
+	ID                 types.String `tfsdk:"id"`
+	OrganizationID     types.String `tfsdk:"organization_id"`
+	Namespace          types.String `tfsdk:"namespace"`
+	Name               types.String `tfsdk:"name"`
+	System             types.String `tfsdk:"system"`
+	Description        types.String `tfsdk:"description"`
+	Source             types.String `tfsdk:"source"`
+	CreatedBy          types.String `tfsdk:"created_by"`
+	CreatedAt          types.String `tfsdk:"created_at"`
+	UpdatedAt          types.String `tfsdk:"updated_at"`
+	Deprecated         types.Bool   `tfsdk:"deprecated"`
+	DeprecatedAt       types.String `tfsdk:"deprecated_at"`
+	DeprecationMessage types.String `tfsdk:"deprecation_message"`
+	SuccessorModuleID  types.String `tfsdk:"successor_module_id"`
 }
 
 func NewModuleResource() resource.Resource {
@@ -105,6 +109,22 @@ func (r *ModuleResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the module was last updated.",
+				Computed:    true,
+			},
+			"deprecated": schema.BoolAttribute{
+				Description: "Whether the module is currently marked deprecated. Read-only here; manage with `registry_module_deprecation`.",
+				Computed:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the module was deprecated, if applicable.",
+				Computed:    true,
+			},
+			"deprecation_message": schema.StringAttribute{
+				Description: "Optional message explaining why the module was deprecated.",
+				Computed:    true,
+			},
+			"successor_module_id": schema.StringAttribute{
+				Description: "UUID of the successor module that replaces this one, if specified at deprecation time.",
 				Computed:    true,
 			},
 		},
@@ -229,6 +249,7 @@ func moduleToModel(m *client.Module) ModuleResourceModel {
 		System:         types.StringValue(m.System),
 		CreatedAt:      types.StringValue(normalizeTimestamp(m.CreatedAt)),
 		UpdatedAt:      types.StringValue(normalizeTimestamp(m.UpdatedAt)),
+		Deprecated:     types.BoolValue(m.Deprecated),
 	}
 	if m.Description != nil {
 		model.Description = types.StringValue(*m.Description)
@@ -244,6 +265,21 @@ func moduleToModel(m *client.Module) ModuleResourceModel {
 		model.CreatedBy = types.StringValue(*m.CreatedBy)
 	} else {
 		model.CreatedBy = types.StringNull()
+	}
+	if m.DeprecatedAt != nil {
+		model.DeprecatedAt = types.StringValue(normalizeTimestamp(*m.DeprecatedAt))
+	} else {
+		model.DeprecatedAt = types.StringNull()
+	}
+	if m.DeprecationMessage != nil {
+		model.DeprecationMessage = types.StringValue(*m.DeprecationMessage)
+	} else {
+		model.DeprecationMessage = types.StringNull()
+	}
+	if m.SuccessorModuleID != nil {
+		model.SuccessorModuleID = types.StringValue(*m.SuccessorModuleID)
+	} else {
+		model.SuccessorModuleID = types.StringNull()
 	}
 	return model
 }


### PR DESCRIPTION
Closes #13

## Summary

Backend's `models.Module` carries module-level deprecation state (`deprecated`, `deprecated_at`, `deprecation_message`, `successor_module_id`) set via `POST /api/v1/modules/{ns}/{name}/{sys}/deprecate`. The provider's client struct dropped all four fields, so users couldn't detect drift if a module was deprecated out-of-band.

This PR:
- Adds the four fields to `client.Module`.
- Surfaces them as computed-only attributes on `registry_module` and `data.registry_modules`.
- Adds a client unit test that round-trips a deprecated-module payload.

Managing the deprecation lifecycle from Terraform (POST/DELETE on the deprecate endpoint) is the job of a future `registry_module_deprecation` resource — tracked separately in #20.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/client/...` passes
- [x] `go test ./internal/provider/...` passes
- [ ] Acceptance test (CI): create a module, deprecate it via the backend API directly, refresh state, confirm `deprecated = true`

## Changelog
- feat: `registry_module` exposes computed deprecation state (`deprecated`, `deprecated_at`, `deprecation_message`, `successor_module_id`)