### PR TITLE
feat(mirror): support pull-through caching

### DIFF
--- a/internal/client/mirrors_test.go
+++ b/internal/client/mirrors_test.go
@@ -73,6 +73,35 @@ func TestUpdateTerraformMirrorRequest_OmitsUnsetFields(t *testing.T) {
 	}
 }
 
+// TestMirror_DecodesPullThroughFields covers the addition in #14 — backend
+// MirrorConfiguration carries pull_through_enabled and
+// pull_through_cache_ttl_hours for opt-in pull-through caching of providers
+// from the upstream registry. The previous client struct dropped both.
+func TestMirror_DecodesPullThroughFields(t *testing.T) {
+	body := []byte(`{
+		"id": "11111111-1111-1111-1111-111111111111",
+		"name": "hashicorp",
+		"upstream_registry_url": "https://registry.terraform.io",
+		"enabled": true,
+		"sync_interval_hours": 24,
+		"pull_through_enabled": true,
+		"pull_through_cache_ttl_hours": 12,
+		"created_at": "2026-04-30T00:00:00Z",
+		"updated_at": "2026-04-30T00:00:00Z"
+	}`)
+
+	var m Mirror
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !m.PullThroughEnabled {
+		t.Errorf("PullThroughEnabled = false, want true")
+	}
+	if m.PullThroughCacheTTLHours != 12 {
+		t.Errorf("PullThroughCacheTTLHours = %d, want 12", m.PullThroughCacheTTLHours)
+	}
+}
+
 // TestCreateMirrorRequest_RequiredFieldsPresent confirms required scalars
 // (which are not pointers) still ship even when other fields are unset.
 func TestCreateMirrorRequest_RequiredFieldsPresent(t *testing.T) {

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -266,23 +266,25 @@ type UpdateModuleSCMLinkRequest struct {
 
 // Mirror represents a provider mirror configuration.
 type Mirror struct {
-	ID                  string   `json:"id"`
-	Name                string   `json:"name"`
-	Description         *string  `json:"description,omitempty"`
-	UpstreamRegistryURL string   `json:"upstream_registry_url"`
-	OrganizationID      *string  `json:"organization_id,omitempty"`
-	NamespaceFilter     []string `json:"namespace_filter,omitempty"`
-	ProviderFilter      []string `json:"provider_filter,omitempty"`
-	VersionFilter       *string  `json:"version_filter,omitempty"`
-	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             bool     `json:"enabled"`
-	SyncIntervalHours   int      `json:"sync_interval_hours"`
-	LastSyncAt          *string  `json:"last_sync_at,omitempty"`
-	LastSyncStatus      *string  `json:"last_sync_status,omitempty"`
-	LastSyncError       *string  `json:"last_sync_error,omitempty"`
-	CreatedAt           string   `json:"created_at"`
-	UpdatedAt           string   `json:"updated_at"`
-	CreatedBy           *string  `json:"created_by,omitempty"`
+	ID                       string   `json:"id"`
+	Name                     string   `json:"name"`
+	Description              *string  `json:"description,omitempty"`
+	UpstreamRegistryURL      string   `json:"upstream_registry_url"`
+	OrganizationID           *string  `json:"organization_id,omitempty"`
+	NamespaceFilter          []string `json:"namespace_filter,omitempty"`
+	ProviderFilter           []string `json:"provider_filter,omitempty"`
+	VersionFilter            *string  `json:"version_filter,omitempty"`
+	PlatformFilter           []string `json:"platform_filter,omitempty"`
+	Enabled                  bool     `json:"enabled"`
+	SyncIntervalHours        int      `json:"sync_interval_hours"`
+	PullThroughEnabled       bool     `json:"pull_through_enabled"`
+	PullThroughCacheTTLHours int      `json:"pull_through_cache_ttl_hours"`
+	LastSyncAt               *string  `json:"last_sync_at,omitempty"`
+	LastSyncStatus           *string  `json:"last_sync_status,omitempty"`
+	LastSyncError            *string  `json:"last_sync_error,omitempty"`
+	CreatedAt                string   `json:"created_at"`
+	UpdatedAt                string   `json:"updated_at"`
+	CreatedBy                *string  `json:"created_by,omitempty"`
 }
 
 // CreateMirrorRequest is the payload for creating a mirror.
@@ -292,16 +294,18 @@ type Mirror struct {
 // CreateMirrorConfigRequest semantics in
 // backend/internal/db/models/mirror.go.
 type CreateMirrorRequest struct {
-	Name                string   `json:"name"`
-	Description         *string  `json:"description,omitempty"`
-	UpstreamRegistryURL string   `json:"upstream_registry_url"`
-	OrganizationID      *string  `json:"organization_id,omitempty"`
-	NamespaceFilter     []string `json:"namespace_filter,omitempty"`
-	ProviderFilter      []string `json:"provider_filter,omitempty"`
-	VersionFilter       *string  `json:"version_filter,omitempty"`
-	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             *bool    `json:"enabled,omitempty"`
-	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
+	Name                     string   `json:"name"`
+	Description              *string  `json:"description,omitempty"`
+	UpstreamRegistryURL      string   `json:"upstream_registry_url"`
+	OrganizationID           *string  `json:"organization_id,omitempty"`
+	NamespaceFilter          []string `json:"namespace_filter,omitempty"`
+	ProviderFilter           []string `json:"provider_filter,omitempty"`
+	VersionFilter            *string  `json:"version_filter,omitempty"`
+	PlatformFilter           []string `json:"platform_filter,omitempty"`
+	Enabled                  *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours        *int     `json:"sync_interval_hours,omitempty"`
+	PullThroughEnabled       *bool    `json:"pull_through_enabled,omitempty"`
+	PullThroughCacheTTLHours *int     `json:"pull_through_cache_ttl_hours,omitempty"`
 }
 
 // UpdateMirrorRequest is the payload for updating a mirror.
@@ -312,16 +316,18 @@ type CreateMirrorRequest struct {
 // bool/int zero values would silently disable the mirror or reset its sync
 // interval to zero.
 type UpdateMirrorRequest struct {
-	Name                *string  `json:"name,omitempty"`
-	Description         *string  `json:"description,omitempty"`
-	UpstreamRegistryURL *string  `json:"upstream_registry_url,omitempty"`
-	OrganizationID      *string  `json:"organization_id,omitempty"`
-	NamespaceFilter     []string `json:"namespace_filter,omitempty"`
-	ProviderFilter      []string `json:"provider_filter,omitempty"`
-	VersionFilter       *string  `json:"version_filter,omitempty"`
-	PlatformFilter      []string `json:"platform_filter,omitempty"`
-	Enabled             *bool    `json:"enabled,omitempty"`
-	SyncIntervalHours   *int     `json:"sync_interval_hours,omitempty"`
+	Name                     *string  `json:"name,omitempty"`
+	Description              *string  `json:"description,omitempty"`
+	UpstreamRegistryURL      *string  `json:"upstream_registry_url,omitempty"`
+	OrganizationID           *string  `json:"organization_id,omitempty"`
+	NamespaceFilter          []string `json:"namespace_filter,omitempty"`
+	ProviderFilter           []string `json:"provider_filter,omitempty"`
+	VersionFilter            *string  `json:"version_filter,omitempty"`
+	PlatformFilter           []string `json:"platform_filter,omitempty"`
+	Enabled                  *bool    `json:"enabled,omitempty"`
+	SyncIntervalHours        *int     `json:"sync_interval_hours,omitempty"`
+	PullThroughEnabled       *bool    `json:"pull_through_enabled,omitempty"`
+	PullThroughCacheTTLHours *int     `json:"pull_through_cache_ttl_hours,omitempty"`
 }
 
 // TerraformMirror represents a Terraform binary mirror configuration.

--- a/internal/provider/datasource_mirrors.go
+++ b/internal/provider/datasource_mirrors.go
@@ -21,17 +21,19 @@ type MirrorsDataSourceModel struct {
 }
 
 type MirrorDSItem struct {
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	Description         types.String `tfsdk:"description"`
-	UpstreamRegistryURL types.String `tfsdk:"upstream_registry_url"`
-	OrganizationID      types.String `tfsdk:"organization_id"`
-	Enabled             types.Bool   `tfsdk:"enabled"`
-	SyncIntervalHours   types.Int64  `tfsdk:"sync_interval_hours"`
-	LastSyncAt          types.String `tfsdk:"last_sync_at"`
-	LastSyncStatus      types.String `tfsdk:"last_sync_status"`
-	CreatedAt           types.String `tfsdk:"created_at"`
-	UpdatedAt           types.String `tfsdk:"updated_at"`
+	ID                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	Description              types.String `tfsdk:"description"`
+	UpstreamRegistryURL      types.String `tfsdk:"upstream_registry_url"`
+	OrganizationID           types.String `tfsdk:"organization_id"`
+	Enabled                  types.Bool   `tfsdk:"enabled"`
+	SyncIntervalHours        types.Int64  `tfsdk:"sync_interval_hours"`
+	PullThroughEnabled       types.Bool   `tfsdk:"pull_through_enabled"`
+	PullThroughCacheTTLHours types.Int64  `tfsdk:"pull_through_cache_ttl_hours"`
+	LastSyncAt               types.String `tfsdk:"last_sync_at"`
+	LastSyncStatus           types.String `tfsdk:"last_sync_status"`
+	CreatedAt                types.String `tfsdk:"created_at"`
+	UpdatedAt                types.String `tfsdk:"updated_at"`
 }
 
 func NewMirrorsDataSource() datasource.DataSource {
@@ -51,17 +53,19 @@ func (d *MirrorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id":                    schema.StringAttribute{Computed: true, Description: "UUID."},
-						"name":                  schema.StringAttribute{Computed: true, Description: "Mirror name."},
-						"description":           schema.StringAttribute{Computed: true, Description: "Description."},
-						"upstream_registry_url": schema.StringAttribute{Computed: true, Description: "Upstream registry URL."},
-						"organization_id":       schema.StringAttribute{Computed: true, Description: "Organization UUID."},
-						"enabled":               schema.BoolAttribute{Computed: true, Description: "Whether syncing is enabled."},
-						"sync_interval_hours":   schema.Int64Attribute{Computed: true, Description: "Sync interval in hours."},
-						"last_sync_at":          schema.StringAttribute{Computed: true, Description: "Last sync timestamp."},
-						"last_sync_status":      schema.StringAttribute{Computed: true, Description: "Last sync status."},
-						"created_at":            schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
-						"updated_at":            schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
+						"id":                           schema.StringAttribute{Computed: true, Description: "UUID."},
+						"name":                         schema.StringAttribute{Computed: true, Description: "Mirror name."},
+						"description":                  schema.StringAttribute{Computed: true, Description: "Description."},
+						"upstream_registry_url":        schema.StringAttribute{Computed: true, Description: "Upstream registry URL."},
+						"organization_id":              schema.StringAttribute{Computed: true, Description: "Organization UUID."},
+						"enabled":                      schema.BoolAttribute{Computed: true, Description: "Whether syncing is enabled."},
+						"sync_interval_hours":          schema.Int64Attribute{Computed: true, Description: "Sync interval in hours."},
+						"pull_through_enabled":         schema.BoolAttribute{Computed: true, Description: "Whether pull-through caching is enabled."},
+						"pull_through_cache_ttl_hours": schema.Int64Attribute{Computed: true, Description: "Pull-through cache TTL in hours."},
+						"last_sync_at":                 schema.StringAttribute{Computed: true, Description: "Last sync timestamp."},
+						"last_sync_status":             schema.StringAttribute{Computed: true, Description: "Last sync status."},
+						"created_at":                   schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
+						"updated_at":                   schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
 				},
 			},
@@ -97,13 +101,15 @@ func (d *MirrorsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	items := make([]MirrorDSItem, len(mirrors))
 	for i, m := range mirrors {
 		item := MirrorDSItem{
-			ID:                  types.StringValue(m.ID),
-			Name:                types.StringValue(m.Name),
-			UpstreamRegistryURL: types.StringValue(m.UpstreamRegistryURL),
-			Enabled:             types.BoolValue(m.Enabled),
-			SyncIntervalHours:   types.Int64Value(int64(m.SyncIntervalHours)),
-			CreatedAt:           types.StringValue(m.CreatedAt),
-			UpdatedAt:           types.StringValue(m.UpdatedAt),
+			ID:                       types.StringValue(m.ID),
+			Name:                     types.StringValue(m.Name),
+			UpstreamRegistryURL:      types.StringValue(m.UpstreamRegistryURL),
+			Enabled:                  types.BoolValue(m.Enabled),
+			SyncIntervalHours:        types.Int64Value(int64(m.SyncIntervalHours)),
+			PullThroughEnabled:       types.BoolValue(m.PullThroughEnabled),
+			PullThroughCacheTTLHours: types.Int64Value(int64(m.PullThroughCacheTTLHours)),
+			CreatedAt:                types.StringValue(m.CreatedAt),
+			UpdatedAt:                types.StringValue(m.UpdatedAt),
 		}
 		if m.Description != nil {
 			item.Description = types.StringValue(*m.Description)

--- a/internal/provider/resource_mirror.go
+++ b/internal/provider/resource_mirror.go
@@ -22,21 +22,23 @@ type MirrorResource struct {
 }
 
 type MirrorResourceModel struct {
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	Description         types.String `tfsdk:"description"`
-	UpstreamRegistryURL types.String `tfsdk:"upstream_registry_url"`
-	OrganizationID      types.String `tfsdk:"organization_id"`
-	NamespaceFilter     types.List   `tfsdk:"namespace_filter"`
-	ProviderFilter      types.List   `tfsdk:"provider_filter"`
-	VersionFilter       types.String `tfsdk:"version_filter"`
-	PlatformFilter      types.List   `tfsdk:"platform_filter"`
-	Enabled             types.Bool   `tfsdk:"enabled"`
-	SyncIntervalHours   types.Int64  `tfsdk:"sync_interval_hours"`
-	LastSyncAt          types.String `tfsdk:"last_sync_at"`
-	LastSyncStatus      types.String `tfsdk:"last_sync_status"`
-	CreatedAt           types.String `tfsdk:"created_at"`
-	UpdatedAt           types.String `tfsdk:"updated_at"`
+	ID                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	Description              types.String `tfsdk:"description"`
+	UpstreamRegistryURL      types.String `tfsdk:"upstream_registry_url"`
+	OrganizationID           types.String `tfsdk:"organization_id"`
+	NamespaceFilter          types.List   `tfsdk:"namespace_filter"`
+	ProviderFilter           types.List   `tfsdk:"provider_filter"`
+	VersionFilter            types.String `tfsdk:"version_filter"`
+	PlatformFilter           types.List   `tfsdk:"platform_filter"`
+	Enabled                  types.Bool   `tfsdk:"enabled"`
+	SyncIntervalHours        types.Int64  `tfsdk:"sync_interval_hours"`
+	PullThroughEnabled       types.Bool   `tfsdk:"pull_through_enabled"`
+	PullThroughCacheTTLHours types.Int64  `tfsdk:"pull_through_cache_ttl_hours"`
+	LastSyncAt               types.String `tfsdk:"last_sync_at"`
+	LastSyncStatus           types.String `tfsdk:"last_sync_status"`
+	CreatedAt                types.String `tfsdk:"created_at"`
+	UpdatedAt                types.String `tfsdk:"updated_at"`
 }
 
 func NewMirrorResource() resource.Resource {
@@ -111,6 +113,18 @@ func (r *MirrorResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Computed:    true,
 				Default:     int64default.StaticInt64(24),
 			},
+			"pull_through_enabled": schema.BoolAttribute{
+				Description: "Whether to fetch missing providers on demand from the upstream registry, in addition to the periodic sync. Defaults to false.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+			"pull_through_cache_ttl_hours": schema.Int64Attribute{
+				Description: "How long to cache pull-through entries before re-checking upstream. Defaults to 24 hours.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(24),
+			},
 			"last_sync_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp of last sync.",
 				Computed:    true,
@@ -164,6 +178,14 @@ func (r *MirrorResource) Create(ctx context.Context, req resource.CreateRequest,
 	if !plan.SyncIntervalHours.IsNull() && !plan.SyncIntervalHours.IsUnknown() {
 		v := int(plan.SyncIntervalHours.ValueInt64())
 		createReq.SyncIntervalHours = &v
+	}
+	if !plan.PullThroughEnabled.IsNull() && !plan.PullThroughEnabled.IsUnknown() {
+		v := plan.PullThroughEnabled.ValueBool()
+		createReq.PullThroughEnabled = &v
+	}
+	if !plan.PullThroughCacheTTLHours.IsNull() && !plan.PullThroughCacheTTLHours.IsUnknown() {
+		v := int(plan.PullThroughCacheTTLHours.ValueInt64())
+		createReq.PullThroughCacheTTLHours = &v
 	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -240,6 +262,14 @@ func (r *MirrorResource) Update(ctx context.Context, req resource.UpdateRequest,
 		v := int(plan.SyncIntervalHours.ValueInt64())
 		updateReq.SyncIntervalHours = &v
 	}
+	if !plan.PullThroughEnabled.IsNull() && !plan.PullThroughEnabled.IsUnknown() {
+		v := plan.PullThroughEnabled.ValueBool()
+		updateReq.PullThroughEnabled = &v
+	}
+	if !plan.PullThroughCacheTTLHours.IsNull() && !plan.PullThroughCacheTTLHours.IsUnknown() {
+		v := int(plan.PullThroughCacheTTLHours.ValueInt64())
+		updateReq.PullThroughCacheTTLHours = &v
+	}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
 		updateReq.Description = &v
@@ -313,16 +343,18 @@ func mirrorToModel(ctx context.Context, m *client.Mirror) MirrorResourceModel {
 	platList, _ := types.ListValueFrom(ctx, types.StringType, plf)
 
 	model := MirrorResourceModel{
-		ID:                  types.StringValue(m.ID),
-		Name:                types.StringValue(m.Name),
-		UpstreamRegistryURL: types.StringValue(m.UpstreamRegistryURL),
-		Enabled:             types.BoolValue(m.Enabled),
-		SyncIntervalHours:   types.Int64Value(int64(m.SyncIntervalHours)),
-		NamespaceFilter:     nsList,
-		ProviderFilter:      provList,
-		PlatformFilter:      platList,
-		CreatedAt:           types.StringValue(normalizeTimestamp(m.CreatedAt)),
-		UpdatedAt:           types.StringValue(normalizeTimestamp(m.UpdatedAt)),
+		ID:                       types.StringValue(m.ID),
+		Name:                     types.StringValue(m.Name),
+		UpstreamRegistryURL:      types.StringValue(m.UpstreamRegistryURL),
+		Enabled:                  types.BoolValue(m.Enabled),
+		SyncIntervalHours:        types.Int64Value(int64(m.SyncIntervalHours)),
+		PullThroughEnabled:       types.BoolValue(m.PullThroughEnabled),
+		PullThroughCacheTTLHours: types.Int64Value(int64(m.PullThroughCacheTTLHours)),
+		NamespaceFilter:          nsList,
+		ProviderFilter:           provList,
+		PlatformFilter:           platList,
+		CreatedAt:                types.StringValue(normalizeTimestamp(m.CreatedAt)),
+		UpdatedAt:                types.StringValue(normalizeTimestamp(m.UpdatedAt)),
 	}
 	if m.Description != nil {
 		model.Description = types.StringValue(*m.Description)


### PR DESCRIPTION
Closes #14

## Summary

Backend's `MirrorConfiguration` carries `pull_through_enabled` and `pull_through_cache_ttl_hours`, letting the registry serve missing providers on demand by fetching from upstream and caching for the configured TTL. The provider's mirror model dropped both.

This PR:
- Adds the two fields on `client.Mirror` (response) and on Create/Update requests as pointers (omitted-field semantics).
- Adds them to `registry_mirror` schema with defaults `false` / `24` hours.
- Surfaces them on `data.registry_mirrors` as computed-only.
- Adds a client unit test for the new fields.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/client/...` passes
- [x] `go test ./internal/provider/...` passes
- [ ] Acceptance test (CI): create a mirror with `pull_through_enabled = true, pull_through_cache_ttl_hours = 12`, confirm round-trip

## Changelog
- feat: `registry_mirror` supports `pull_through_enabled` and `pull_through_cache_ttl_hours`