### PR TITLE
chore(deployments): pin acceptance-test backend image to v1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,11 @@ go test -v -count=1 ./internal/client/...
 
 For changes that affect provider behaviour, run the acceptance tests too:
 
+The test stack in `deployments/docker-compose.test.yml` pins the backend image to a specific
+version tag (e.g. `ghcr.io/sethbacon/terraform-registry-backend:v1.0.0`). Bump this pin in
+lockstep with backend major releases; otherwise leave it at the current pinned tag so that
+acceptance tests run against a known-good backend rather than a moving `latest`.
+
 ```bash
 # Start the test backend
 docker compose -f deployments/docker-compose.test.yml up -d

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
       retries: 15
 
   backend:
-    image: ghcr.io/sethbacon/terraform-registry-backend:latest
+    image: ghcr.io/sethbacon/terraform-registry-backend:v1.0.0
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432


### PR DESCRIPTION
## Summary

- Bumps `deployments/docker-compose.test.yml` backend image from `latest` to `ghcr.io/sethbacon/terraform-registry-backend:v1.0.0`
- Documents the pin policy in CONTRIBUTING.md: bump in lockstep with backend major releases

## Changelog
- chore: pin acceptance-test backend image to v1.0.0 and document pin policy in CONTRIBUTING

Closes #33