### PR TITLE
feat(provider): probe backend GET /version on configure and warn on incompatible versions

### DIFF
--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -1,0 +1,22 @@
+package client
+
+import "context"
+
+// BackendVersion holds the response from GET /version.
+type BackendVersion struct {
+	Version         string   `json:"version"`
+	BuildDate       string   `json:"build_date"`
+	APIVersion      string   `json:"api_version"`
+	DefaultLanguage string   `json:"default_language"`
+	Protocols       []string `json:"protocols"`
+	Capabilities    []string `json:"capabilities"`
+}
+
+// GetVersion calls GET /version and returns the backend version info.
+func (c *Client) GetVersion(ctx context.Context) (*BackendVersion, error) {
+	var v BackendVersion
+	if err := c.Get(ctx, "/version", &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}

--- a/internal/client/version_test.go
+++ b/internal/client/version_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBackendVersion_Decode(t *testing.T) {
+	body := []byte(`{
+		"version": "1.0.0",
+		"build_date": "2026-04-01T00:00:00Z",
+		"api_version": "1",
+		"default_language": "en",
+		"protocols": ["terraform.io/v1"],
+		"capabilities": ["modules", "providers"]
+	}`)
+
+	var v BackendVersion
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if v.Version != "1.0.0" {
+		t.Errorf("Version = %q, want 1.0.0", v.Version)
+	}
+	if v.APIVersion != "1" {
+		t.Errorf("APIVersion = %q, want 1", v.APIVersion)
+	}
+	if len(v.Protocols) != 1 || v.Protocols[0] != "terraform.io/v1" {
+		t.Errorf("Protocols = %v, want [terraform.io/v1]", v.Protocols)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,9 @@ import (
 var _ provider.Provider = &RegistryProvider{}
 var _ provider.ProviderWithFunctions = &RegistryProvider{}
 
+// minSupportedBackendVersion is the oldest backend version the provider is known to work with.
+const minSupportedBackendVersion = "1.0.0"
+
 // RegistryProvider implements the Terraform Registry provider.
 type RegistryProvider struct {
 	version string
@@ -25,11 +28,12 @@ type RegistryProvider struct {
 
 // RegistryProviderModel holds provider-level configuration.
 type RegistryProviderModel struct {
-	Endpoint   types.String `tfsdk:"endpoint"`
-	Token      types.String `tfsdk:"token"`
-	Insecure   types.Bool   `tfsdk:"insecure"`
-	Timeout    types.Int64  `tfsdk:"timeout"`
-	MaxRetries types.Int64  `tfsdk:"max_retries"`
+	Endpoint     types.String `tfsdk:"endpoint"`
+	Token        types.String `tfsdk:"token"`
+	Insecure     types.Bool   `tfsdk:"insecure"`
+	Timeout      types.Int64  `tfsdk:"timeout"`
+	MaxRetries   types.Int64  `tfsdk:"max_retries"`
+	VersionCheck types.Bool   `tfsdk:"version_check"`
 }
 
 // New returns a provider factory function.
@@ -69,6 +73,10 @@ func (p *RegistryProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			},
 			"max_retries": schema.Int64Attribute{
 				Description: "Maximum number of retries for failed requests (429, 5xx). Defaults to 3.",
+				Optional:    true,
+			},
+			"version_check": schema.BoolAttribute{
+				Description: "Probe the backend GET /version on configure and warn if the backend is older than the minimum supported version. Defaults to true. Set to false to disable.",
 				Optional:    true,
 			},
 		},
@@ -126,6 +134,11 @@ func (p *RegistryProvider) Configure(ctx context.Context, req provider.Configure
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Provider Configuration", err.Error())
 		return
+	}
+
+	skipVersionCheck := !config.VersionCheck.IsNull() && !config.VersionCheck.IsUnknown() && !config.VersionCheck.ValueBool()
+	if !skipVersionCheck {
+		probeBackendVersion(ctx, c, resp)
 	}
 
 	resp.DataSourceData = c

--- a/internal/provider/semver.go
+++ b/internal/provider/semver.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type semver struct{ major, minor, patch int }
+
+// parseSemver parses a "vX.Y.Z" or "X.Y.Z" string.
+func parseSemver(s string) (semver, error) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return semver{}, fmt.Errorf("invalid semver %q", s)
+	}
+	var v semver
+	var err error
+	if v.major, err = strconv.Atoi(parts[0]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	if v.minor, err = strconv.Atoi(parts[1]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	if v.patch, err = strconv.Atoi(parts[2]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	return v, nil
+}
+
+// less reports whether v is strictly less than other.
+func (v semver) less(other semver) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	return v.patch < other.patch
+}

--- a/internal/provider/semver_test.go
+++ b/internal/provider/semver_test.go
@@ -1,0 +1,55 @@
+package provider
+
+import "testing"
+
+func TestParseSemver(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+		major   int
+		minor   int
+		patch   int
+	}{
+		{"1.0.0", false, 1, 0, 0},
+		{"v1.2.3", false, 1, 2, 3},
+		{"0.9.99", false, 0, 9, 99},
+		{"bad", true, 0, 0, 0},
+		{"1.2", true, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		got, err := parseSemver(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseSemver(%q): expected error, got none", tc.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSemver(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got.major != tc.major || got.minor != tc.minor || got.patch != tc.patch {
+			t.Errorf("parseSemver(%q) = %+v, want {%d %d %d}", tc.input, got, tc.major, tc.minor, tc.patch)
+		}
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.9.0", "1.0.0", true},
+		{"1.0.0", "1.0.0", false},
+		{"1.0.1", "1.0.0", false},
+		{"1.0.0", "1.0.1", true},
+		{"2.0.0", "1.9.9", false},
+	}
+	for _, tc := range cases {
+		a, _ := parseSemver(tc.a)
+		b, _ := parseSemver(tc.b)
+		if got := a.less(b); got != tc.want {
+			t.Errorf("%s < %s: got %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/provider/version_probe.go
+++ b/internal/provider/version_probe.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+// probeBackendVersion calls GET /version and adds a warning diagnostic if the
+// backend is older than minSupportedBackendVersion or the endpoint is unreachable.
+func probeBackendVersion(ctx context.Context, c *client.Client, resp *provider.ConfigureResponse) {
+	bv, err := c.GetVersion(ctx)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Backend Version Check Failed",
+			fmt.Sprintf(
+				"Could not reach GET /version on the registry endpoint: %s. "+
+					"Verify the endpoint is correct and that /version is accessible. "+
+					"The provider will still attempt to operate normally.",
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	min, err := parseSemver(minSupportedBackendVersion)
+	if err != nil {
+		return
+	}
+
+	got, err := parseSemver(bv.Version)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Backend Version Unrecognized",
+			fmt.Sprintf(
+				"The backend reported version %q which could not be parsed as a semantic version. "+
+					"Minimum supported backend version is %s.",
+				bv.Version, minSupportedBackendVersion,
+			),
+		)
+		return
+	}
+
+	if got.less(min) {
+		resp.Diagnostics.AddWarning(
+			"Unsupported Backend Version",
+			fmt.Sprintf(
+				"The registry backend is running version %s, but this provider requires at least %s. "+
+					"Upgrade the backend to avoid API errors. "+
+					"Set version_check = false in the provider block to suppress this warning.",
+				bv.Version, minSupportedBackendVersion,
+			),
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `version_check` provider attribute (default `true`) that calls `GET /version` after configure
- Emits a Terraform **warning** diagnostic (not an error) when the backend is older than `1.0.0` or unreachable
- Users can opt out with `version_check = false` in the provider block
- Adds `client.GetVersion` / `client.BackendVersion` model
- Adds a minimal semver parser in the provider package with unit tests

## Changelog
- feat: provider probes backend `GET /version` on configure and warns on unsupported backend versions; opt out with `version_check = false`

Closes #32