### PR TITLE
feat: add module/version deprecation and provider version deprecation resources

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -164,6 +164,37 @@ type UpdateModuleRequest struct {
 	Source      *string `json:"source,omitempty"`
 }
 
+// ModuleVersion represents a single version of a registry module.
+type ModuleVersion struct {
+	ID                 string  `json:"id"`
+	Version            string  `json:"version"`
+	Deprecated         bool    `json:"deprecated"`
+	DeprecatedAt       *string `json:"deprecated_at,omitempty"`
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+	ReplacementSource  *string `json:"replacement_source,omitempty"`
+}
+
+// DeprecateModuleRequest is the payload for deprecating a module or module version.
+type DeprecateModuleRequest struct {
+	Message           string  `json:"message"`
+	SuccessorModuleID *string `json:"successor_module_id,omitempty"`
+	ReplacementSource *string `json:"replacement_source,omitempty"`
+}
+
+// ProviderVersion represents a single version of a registry provider.
+type ProviderVersion struct {
+	ID                 string  `json:"id"`
+	Version            string  `json:"version"`
+	Deprecated         bool    `json:"deprecated"`
+	DeprecatedAt       *string `json:"deprecated_at,omitempty"`
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+}
+
+// DeprecateProviderVersionRequest is the payload for deprecating a provider version.
+type DeprecateProviderVersionRequest struct {
+	Message string `json:"message"`
+}
+
 // ProviderRecord represents a registry provider record.
 type ProviderRecord struct {
 	ID             string  `json:"id"`

--- a/internal/client/module_deprecations.go
+++ b/internal/client/module_deprecations.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeprecateModule sets module-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/deprecate.
+func (c *Client) DeprecateModule(ctx context.Context, namespace, name, system string, req DeprecateModuleRequest) (*Module, error) {
+	var mod Module
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/deprecate", namespace, name, system)
+	if err := c.Post(ctx, path, req, &mod); err != nil {
+		return nil, err
+	}
+	return &mod, nil
+}
+
+// UndeprecateModule removes module-level deprecation via DELETE /api/v1/modules/{ns}/{name}/{sys}/deprecate.
+func (c *Client) UndeprecateModule(ctx context.Context, namespace, name, system string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/modules/%s/%s/%s/deprecate", namespace, name, system))
+}
+
+// GetModuleVersion fetches a single module version for inspecting deprecation state.
+func (c *Client) GetModuleVersion(ctx context.Context, namespace, name, system, version string) (*ModuleVersion, error) {
+	var mv ModuleVersion
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/%s", namespace, name, system, version)
+	if err := c.Get(ctx, path, &mv); err != nil {
+		return nil, err
+	}
+	return &mv, nil
+}
+
+// DeprecateModuleVersion sets version-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/versions/{ver}/deprecate.
+func (c *Client) DeprecateModuleVersion(ctx context.Context, namespace, name, system, version string, req DeprecateModuleRequest) (*ModuleVersion, error) {
+	var mv ModuleVersion
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/deprecate", namespace, name, system, version)
+	if err := c.Post(ctx, path, req, &mv); err != nil {
+		return nil, err
+	}
+	return &mv, nil
+}
+
+// UndeprecateModuleVersion removes version-level deprecation via DELETE /api/v1/modules/{ns}/{name}/{sys}/versions/{ver}/deprecate.
+func (c *Client) UndeprecateModuleVersion(ctx context.Context, namespace, name, system, version string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/deprecate", namespace, name, system, version))
+}

--- a/internal/client/provider_deprecations.go
+++ b/internal/client/provider_deprecations.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetProviderVersion fetches a single provider version for inspecting deprecation state.
+func (c *Client) GetProviderVersion(ctx context.Context, namespace, providerType, version string) (*ProviderVersion, error) {
+	var pv ProviderVersion
+	path := fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s", namespace, providerType, version)
+	if err := c.Get(ctx, path, &pv); err != nil {
+		return nil, err
+	}
+	return &pv, nil
+}
+
+// DeprecateProviderVersion sets version-level deprecation via POST /api/v1/providers/{ns}/{type}/versions/{ver}/deprecate.
+func (c *Client) DeprecateProviderVersion(ctx context.Context, namespace, providerType, version string, req DeprecateProviderVersionRequest) (*ProviderVersion, error) {
+	var pv ProviderVersion
+	path := fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s/deprecate", namespace, providerType, version)
+	if err := c.Post(ctx, path, req, &pv); err != nil {
+		return nil, err
+	}
+	return &pv, nil
+}
+
+// UndeprecateProviderVersion removes version-level deprecation via DELETE /api/v1/providers/{ns}/{type}/versions/{ver}/deprecate.
+func (c *Client) UndeprecateProviderVersion(ctx context.Context, namespace, providerType, version string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s/deprecate", namespace, providerType, version))
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,6 +161,9 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewStorageConfigResource,
 		NewPolicyResource,
 		NewApprovalRequestResource,
+		NewModuleDeprecationResource,
+		NewModuleVersionDeprecationResource,
+		NewProviderVersionDeprecationResource,
 	}
 }
 

--- a/internal/provider/resource_module_deprecation.go
+++ b/internal/provider/resource_module_deprecation.go
@@ -1,0 +1,201 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ModuleDeprecationResource{}
+
+type ModuleDeprecationResource struct {
+	client *client.Client
+}
+
+type ModuleDeprecationResourceModel struct {
+	Namespace         types.String `tfsdk:"namespace"`
+	Name              types.String `tfsdk:"name"`
+	System            types.String `tfsdk:"system"`
+	Message           types.String `tfsdk:"message"`
+	SuccessorModuleID types.String `tfsdk:"successor_module_id"`
+	DeprecatedAt      types.String `tfsdk:"deprecated_at"`
+}
+
+func NewModuleDeprecationResource() resource.Resource {
+	return &ModuleDeprecationResource{}
+}
+
+func (r *ModuleDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_deprecation"
+}
+
+func (r *ModuleDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a module as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the module.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Module name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.StringAttribute{
+				Description: "Module system (provider name, e.g. 'aws').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"successor_module_id": schema.StringAttribute{
+				Description: "Optional UUID of the successor module (used by Terraform CLI ≥1.10 for replacement guidance).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the module was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ModuleDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ModuleDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.SuccessorModuleID.IsNull() && !plan.SuccessorModuleID.IsUnknown() {
+		v := plan.SuccessorModuleID.ValueString()
+		dreq.SuccessorModuleID = &v
+	}
+
+	mod, err := r.client.DeprecateModule(ctx, plan.Namespace.ValueString(), plan.Name.ValueString(), plan.System.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Module", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(plan, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mod, err := r.client.GetModule(ctx, state.Namespace.ValueString(), state.Name.ValueString(), state.System.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Module", err.Error())
+		return
+	}
+
+	if !mod.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(state, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.SuccessorModuleID.IsNull() && !plan.SuccessorModuleID.IsUnknown() {
+		v := plan.SuccessorModuleID.ValueString()
+		dreq.SuccessorModuleID = &v
+	}
+
+	mod, err := r.client.DeprecateModule(ctx, plan.Namespace.ValueString(), plan.Name.ValueString(), plan.System.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Module Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(plan, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateModule(ctx, state.Namespace.ValueString(), state.Name.ValueString(), state.System.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Module Deprecation", err.Error())
+	}
+}
+
+func moduleDeprecationToModel(ref ModuleDeprecationResourceModel, mod *client.Module) ModuleDeprecationResourceModel {
+	m := ModuleDeprecationResourceModel{
+		Namespace: types.StringValue(mod.Namespace),
+		Name:      types.StringValue(mod.Name),
+		System:    types.StringValue(mod.System),
+		Message:   ref.Message,
+	}
+	if mod.DeprecationMessage != nil {
+		m.Message = types.StringValue(*mod.DeprecationMessage)
+	}
+	if mod.SuccessorModuleID != nil {
+		m.SuccessorModuleID = types.StringValue(*mod.SuccessorModuleID)
+	} else {
+		m.SuccessorModuleID = types.StringNull()
+	}
+	if mod.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*mod.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}

--- a/internal/provider/resource_module_version_deprecation.go
+++ b/internal/provider/resource_module_version_deprecation.go
@@ -1,0 +1,218 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ModuleVersionDeprecationResource{}
+
+type ModuleVersionDeprecationResource struct {
+	client *client.Client
+}
+
+type ModuleVersionDeprecationResourceModel struct {
+	Namespace         types.String `tfsdk:"namespace"`
+	Name              types.String `tfsdk:"name"`
+	System            types.String `tfsdk:"system"`
+	Version           types.String `tfsdk:"version"`
+	Message           types.String `tfsdk:"message"`
+	ReplacementSource types.String `tfsdk:"replacement_source"`
+	DeprecatedAt      types.String `tfsdk:"deprecated_at"`
+}
+
+func NewModuleVersionDeprecationResource() resource.Resource {
+	return &ModuleVersionDeprecationResource{}
+}
+
+func (r *ModuleVersionDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_version_deprecation"
+}
+
+func (r *ModuleVersionDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a specific module version as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the module.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Module name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.StringAttribute{
+				Description: "Module system (provider name, e.g. 'aws').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string of the module version to deprecate.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"replacement_source": schema.StringAttribute{
+				Description: "Optional replacement source address (used by Terraform CLI ≥1.10 for upgrade guidance).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the version was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ModuleVersionDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ModuleVersionDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.ReplacementSource.IsNull() && !plan.ReplacementSource.IsUnknown() {
+		v := plan.ReplacementSource.ValueString()
+		dreq.ReplacementSource = &v
+	}
+
+	mv, err := r.client.DeprecateModuleVersion(ctx,
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Module Version", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(plan, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mv, err := r.client.GetModuleVersion(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Module Version", err.Error())
+		return
+	}
+
+	if !mv.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(state, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.ReplacementSource.IsNull() && !plan.ReplacementSource.IsUnknown() {
+		v := plan.ReplacementSource.ValueString()
+		dreq.ReplacementSource = &v
+	}
+
+	mv, err := r.client.DeprecateModuleVersion(ctx,
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Module Version Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(plan, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateModuleVersion(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Module Version Deprecation", err.Error())
+	}
+}
+
+func moduleVersionDeprecationToModel(ref ModuleVersionDeprecationResourceModel, mv *client.ModuleVersion) ModuleVersionDeprecationResourceModel {
+	m := ModuleVersionDeprecationResourceModel{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+		System:    ref.System,
+		Version:   types.StringValue(mv.Version),
+		Message:   ref.Message,
+	}
+	if mv.DeprecationMessage != nil {
+		m.Message = types.StringValue(*mv.DeprecationMessage)
+	}
+	if mv.ReplacementSource != nil {
+		m.ReplacementSource = types.StringValue(*mv.ReplacementSource)
+	} else {
+		m.ReplacementSource = types.StringNull()
+	}
+	if mv.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*mv.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}

--- a/internal/provider/resource_provider_version_deprecation.go
+++ b/internal/provider/resource_provider_version_deprecation.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ProviderVersionDeprecationResource{}
+
+type ProviderVersionDeprecationResource struct {
+	client *client.Client
+}
+
+type ProviderVersionDeprecationResourceModel struct {
+	Namespace    types.String `tfsdk:"namespace"`
+	Type         types.String `tfsdk:"type"`
+	Version      types.String `tfsdk:"version"`
+	Message      types.String `tfsdk:"message"`
+	DeprecatedAt types.String `tfsdk:"deprecated_at"`
+}
+
+func NewProviderVersionDeprecationResource() resource.Resource {
+	return &ProviderVersionDeprecationResource{}
+}
+
+func (r *ProviderVersionDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_provider_version_deprecation"
+}
+
+func (r *ProviderVersionDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a specific provider version as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the provider.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Description: "Provider type name (e.g. 'aws', 'azurerm').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string of the provider version to deprecate.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the version was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ProviderVersionDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ProviderVersionDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateProviderVersionRequest{
+		Message: plan.Message.ValueString(),
+	}
+
+	pv, err := r.client.DeprecateProviderVersion(ctx,
+		plan.Namespace.ValueString(), plan.Type.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Provider Version", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(plan, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	pv, err := r.client.GetProviderVersion(ctx,
+		state.Namespace.ValueString(), state.Type.ValueString(), state.Version.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Provider Version", err.Error())
+		return
+	}
+
+	if !pv.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(state, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateProviderVersionRequest{
+		Message: plan.Message.ValueString(),
+	}
+
+	pv, err := r.client.DeprecateProviderVersion(ctx,
+		plan.Namespace.ValueString(), plan.Type.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Provider Version Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(plan, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateProviderVersion(ctx,
+		state.Namespace.ValueString(), state.Type.ValueString(), state.Version.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Provider Version Deprecation", err.Error())
+	}
+}
+
+func providerVersionDeprecationToModel(ref ProviderVersionDeprecationResourceModel, pv *client.ProviderVersion) ProviderVersionDeprecationResourceModel {
+	m := ProviderVersionDeprecationResourceModel{
+		Namespace: ref.Namespace,
+		Type:      ref.Type,
+		Version:   types.StringValue(pv.Version),
+		Message:   ref.Message,
+	}
+	if pv.DeprecationMessage != nil {
+		m.Message = types.StringValue(*pv.DeprecationMessage)
+	}
+	if pv.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*pv.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}


### PR DESCRIPTION
## Summary

- `registry_module_deprecation` — marks a module as deprecated (POST/DELETE `/api/v1/modules/{ns}/{name}/{sys}/deprecate`); supports `message` and optional `successor_module_id`
- `registry_module_version_deprecation` — marks a specific module version as deprecated; supports `message` and optional `replacement_source` (Terraform CLI ≥1.10)
- `registry_provider_version_deprecation` — marks a specific provider version as deprecated; supports `message` only (backend does not expose `replacement_source` for providers)
- Read path removes the resource from state if the deprecation has been cleared externally
- Update is re-POST (idempotent); namespace/name/system/version/type fields force-replace

## Changelog
- feat: add `registry_module_deprecation` and `registry_module_version_deprecation` resources
- feat: add `registry_provider_version_deprecation` resource

Closes #20
Closes #21