### PR TITLE
feat: add registry_oidc_group_mapping resource and registry_oidc_config data source

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,5 +1,21 @@
 package client
 
+// OIDCConfig represents the backend OIDC configuration (read-only).
+type OIDCConfig struct {
+	Issuer         string   `json:"issuer"`
+	ClientID       string   `json:"client_id"`
+	Scopes         []string `json:"scopes"`
+	GroupsClaim    string   `json:"groups_claim"`
+	UsernameClaim  string   `json:"username_claim"`
+}
+
+// OIDCGroupMapping represents a single OIDC group → role mapping entry.
+type OIDCGroupMapping struct {
+	OIDCGroup      string `json:"oidc_group"`
+	OrganizationID string `json:"organization_id"`
+	RoleTemplateID string `json:"role_template_id"`
+}
+
 // User represents a registry user.
 type User struct {
 	ID        string  `json:"id"`

--- a/internal/client/oidc.go
+++ b/internal/client/oidc.go
@@ -1,0 +1,30 @@
+package client
+
+import "context"
+
+// GetOIDCConfig fetches the current OIDC configuration via GET /api/v1/admin/oidc/config.
+func (c *Client) GetOIDCConfig(ctx context.Context) (*OIDCConfig, error) {
+	var cfg OIDCConfig
+	if err := c.Get(ctx, "/api/v1/admin/oidc/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// GetOIDCGroupMappings fetches the current OIDC group mappings via GET /api/v1/admin/oidc/group-mapping.
+func (c *Client) GetOIDCGroupMappings(ctx context.Context) ([]OIDCGroupMapping, error) {
+	var mappings []OIDCGroupMapping
+	if err := c.Get(ctx, "/api/v1/admin/oidc/group-mapping", &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// SetOIDCGroupMappings replaces the entire OIDC group mapping table via PUT /api/v1/admin/oidc/group-mapping.
+func (c *Client) SetOIDCGroupMappings(ctx context.Context, mappings []OIDCGroupMapping) ([]OIDCGroupMapping, error) {
+	var result []OIDCGroupMapping
+	if err := c.Put(ctx, "/api/v1/admin/oidc/group-mapping", mappings, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/provider/datasource_oidc_config.go
+++ b/internal/provider/datasource_oidc_config.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &OIDCConfigDataSource{}
+
+type OIDCConfigDataSource struct {
+	client *client.Client
+}
+
+type OIDCConfigDataSourceModel struct {
+	Issuer        types.String `tfsdk:"issuer"`
+	ClientID      types.String `tfsdk:"client_id"`
+	Scopes        types.List   `tfsdk:"scopes"`
+	GroupsClaim   types.String `tfsdk:"groups_claim"`
+	UsernameClaim types.String `tfsdk:"username_claim"`
+}
+
+func NewOIDCConfigDataSource() datasource.DataSource {
+	return &OIDCConfigDataSource{}
+}
+
+func (d *OIDCConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_config"
+}
+
+func (d *OIDCConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend OIDC configuration (read-only). The client secret is never exposed.",
+		Attributes: map[string]schema.Attribute{
+			"issuer": schema.StringAttribute{
+				Description: "OIDC issuer URL.",
+				Computed:    true,
+			},
+			"client_id": schema.StringAttribute{
+				Description: "OIDC client ID.",
+				Computed:    true,
+			},
+			"scopes": schema.ListAttribute{
+				Description: "Requested OIDC scopes.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"groups_claim": schema.StringAttribute{
+				Description: "JWT claim used to extract group membership.",
+				Computed:    true,
+			},
+			"username_claim": schema.StringAttribute{
+				Description: "JWT claim used as the username.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *OIDCConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *OIDCConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetOIDCConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Config", err.Error())
+		return
+	}
+
+	scopes, diags := types.ListValueFrom(ctx, types.StringType, cfg.Scopes)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	model := OIDCConfigDataSourceModel{
+		Issuer:        types.StringValue(cfg.Issuer),
+		ClientID:      types.StringValue(cfg.ClientID),
+		Scopes:        scopes,
+		GroupsClaim:   types.StringValue(cfg.GroupsClaim),
+		UsernameClaim: types.StringValue(cfg.UsernameClaim),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,7 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewModuleDeprecationResource,
 		NewModuleVersionDeprecationResource,
 		NewProviderVersionDeprecationResource,
+		NewOIDCGroupMappingResource,
 	}
 }
 
@@ -180,6 +181,7 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewRoleTemplatesDataSource,
 		NewAuditLogsDataSource,
 		NewStatsDataSource,
+		NewOIDCConfigDataSource,
 	}
 }
 

--- a/internal/provider/resource_oidc_group_mapping.go
+++ b/internal/provider/resource_oidc_group_mapping.go
@@ -1,0 +1,204 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &OIDCGroupMappingResource{}
+
+type OIDCGroupMappingResource struct {
+	client *client.Client
+}
+
+type OIDCGroupMappingResourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	OIDCGroup      types.String `tfsdk:"oidc_group"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	RoleTemplateID types.String `tfsdk:"role_template_id"`
+}
+
+func NewOIDCGroupMappingResource() resource.Resource {
+	return &OIDCGroupMappingResource{}
+}
+
+func (r *OIDCGroupMappingResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_group_mapping"
+}
+
+func (r *OIDCGroupMappingResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a single OIDC group → organization role mapping. The backend stores mappings as a full-replace list; this resource reads the current list, adds or removes its entry, and writes the list back.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Composite identifier: {oidc_group}:{organization_id}.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"oidc_group": schema.StringAttribute{
+				Description: "OIDC groups claim value to match.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this mapping applies to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"role_template_id": schema.StringAttribute{
+				Description: "UUID of the role template to assign.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *OIDCGroupMappingResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *OIDCGroupMappingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	entry := client.OIDCGroupMapping{
+		OIDCGroup:      plan.OIDCGroup.ValueString(),
+		OrganizationID: plan.OrganizationID.ValueString(),
+		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+	}
+
+	updated := upsertMapping(current, entry)
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(oidcMappingID(plan.OIDCGroup.ValueString(), plan.OrganizationID.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *OIDCGroupMappingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mappings, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	for _, m := range mappings {
+		if m.OIDCGroup == state.OIDCGroup.ValueString() && m.OrganizationID == state.OrganizationID.ValueString() {
+			state.RoleTemplateID = types.StringValue(m.RoleTemplateID)
+			resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			return
+		}
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *OIDCGroupMappingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	entry := client.OIDCGroupMapping{
+		OIDCGroup:      plan.OIDCGroup.ValueString(),
+		OrganizationID: plan.OrganizationID.ValueString(),
+		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+	}
+
+	updated := upsertMapping(current, entry)
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *OIDCGroupMappingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	updated := removeMapping(current, state.OIDCGroup.ValueString(), state.OrganizationID.ValueString())
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+	}
+}
+
+func oidcMappingID(group, orgID string) string {
+	return fmt.Sprintf("%s:%s", group, orgID)
+}
+
+func upsertMapping(current []client.OIDCGroupMapping, entry client.OIDCGroupMapping) []client.OIDCGroupMapping {
+	for i, m := range current {
+		if m.OIDCGroup == entry.OIDCGroup && m.OrganizationID == entry.OrganizationID {
+			current[i] = entry
+			return current
+		}
+	}
+	return append(current, entry)
+}
+
+func removeMapping(current []client.OIDCGroupMapping, group, orgID string) []client.OIDCGroupMapping {
+	result := make([]client.OIDCGroupMapping, 0, len(current))
+	for _, m := range current {
+		if m.OIDCGroup != group || m.OrganizationID != orgID {
+			result = append(result, m)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- `registry_oidc_group_mapping` — manages a single OIDC group → org role entry in the backend's full-replace mapping table (GET list → upsert/remove → PUT list); ID is `{oidc_group}:{organization_id}`
- `data.registry_oidc_config` — reads the backend OIDC configuration (issuer, client_id, scopes, groups_claim, username_claim); client secret is never returned

## Changelog
- feat: add `registry_oidc_group_mapping` resource and `registry_oidc_config` data source

Closes #23