### PR TITLE
feat: add terraform mirror version and history data sources

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -453,6 +453,32 @@ type UpdateTerraformMirrorRequest struct {
 	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
+// TerraformMirrorVersionPlatform represents a platform entry for a mirrored Terraform version.
+type TerraformMirrorVersionPlatform struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+	URL  string `json:"url,omitempty"`
+}
+
+// TerraformMirrorVersion represents a single mirrored Terraform/OpenTofu version.
+type TerraformMirrorVersion struct {
+	ID        string                            `json:"id"`
+	Version   string                            `json:"version"`
+	Stable    bool                              `json:"stable"`
+	SyncedAt  *string                           `json:"synced_at,omitempty"`
+	Platforms []TerraformMirrorVersionPlatform  `json:"platforms,omitempty"`
+}
+
+// TerraformMirrorHistoryEntry represents one sync history record for a mirror.
+type TerraformMirrorHistoryEntry struct {
+	ID          string  `json:"id"`
+	StartedAt   string  `json:"started_at"`
+	CompletedAt *string `json:"completed_at,omitempty"`
+	Status      string  `json:"status"`
+	Message     *string `json:"message,omitempty"`
+	VersionsNew int     `json:"versions_new"`
+}
+
 // StorageConfig represents a storage backend configuration.
 type StorageConfig struct {
 	ID          string `json:"id"`

--- a/internal/client/terraform_mirror_versions.go
+++ b/internal/client/terraform_mirror_versions.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListTerraformMirrorVersions returns all versions for a given mirror config.
+func (c *Client) ListTerraformMirrorVersions(ctx context.Context, mirrorID string) ([]TerraformMirrorVersion, error) {
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/versions", mirrorID)
+	items, err := FetchAllPages(ctx, c, path, "versions")
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]TerraformMirrorVersion, 0, len(items))
+	for _, raw := range items {
+		var v TerraformMirrorVersion
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("unmarshaling mirror version: %w", err)
+		}
+		versions = append(versions, v)
+	}
+	return versions, nil
+}
+
+// GetTerraformMirrorVersion returns a single version (including platforms).
+func (c *Client) GetTerraformMirrorVersion(ctx context.Context, mirrorID, version string) (*TerraformMirrorVersion, error) {
+	var v TerraformMirrorVersion
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/versions/%s", mirrorID, version)
+	if err := c.Get(ctx, path, &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// ListTerraformMirrorHistory returns the sync history for a mirror.
+func (c *Client) ListTerraformMirrorHistory(ctx context.Context, mirrorID string) ([]TerraformMirrorHistoryEntry, error) {
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/history", mirrorID)
+	items, err := FetchAllPages(ctx, c, path, "history")
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]TerraformMirrorHistoryEntry, 0, len(items))
+	for _, raw := range items {
+		var e TerraformMirrorHistoryEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("unmarshaling history entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}

--- a/internal/provider/datasource_terraform_mirror_history.go
+++ b/internal/provider/datasource_terraform_mirror_history.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorHistoryDataSource{}
+
+type TerraformMirrorHistoryDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorHistoryEntryModel struct {
+	ID          types.String `tfsdk:"id"`
+	StartedAt   types.String `tfsdk:"started_at"`
+	CompletedAt types.String `tfsdk:"completed_at"`
+	Status      types.String `tfsdk:"status"`
+	Message     types.String `tfsdk:"message"`
+	VersionsNew types.Int64  `tfsdk:"versions_new"`
+}
+
+type TerraformMirrorHistoryDataSourceModel struct {
+	MirrorID types.String                       `tfsdk:"mirror_id"`
+	History  []TerraformMirrorHistoryEntryModel `tfsdk:"history"`
+}
+
+func NewTerraformMirrorHistoryDataSource() datasource.DataSource {
+	return &TerraformMirrorHistoryDataSource{}
+}
+
+func (d *TerraformMirrorHistoryDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_history"
+}
+
+func (d *TerraformMirrorHistoryDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists the sync history entries for a Terraform/OpenTofu mirror configuration.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"history": schema.ListNestedAttribute{
+				Description: "Sync history entries, newest first.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "UUID of the history record.",
+							Computed:    true,
+						},
+						"started_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when the sync started.",
+							Computed:    true,
+						},
+						"completed_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when the sync completed (empty if still running).",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Sync status: 'pending', 'running', 'succeeded', or 'failed'.",
+							Computed:    true,
+						},
+						"message": schema.StringAttribute{
+							Description: "Optional status message or error detail.",
+							Computed:    true,
+						},
+						"versions_new": schema.Int64Attribute{
+							Description: "Number of new versions discovered in this sync.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorHistoryDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorHistoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorHistoryDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	entries, err := d.client.ListTerraformMirrorHistory(ctx, state.MirrorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Terraform Mirror History", err.Error())
+		return
+	}
+
+	items := make([]TerraformMirrorHistoryEntryModel, 0, len(entries))
+	for _, e := range entries {
+		item := TerraformMirrorHistoryEntryModel{
+			ID:          types.StringValue(e.ID),
+			StartedAt:   types.StringValue(normalizeTimestamp(e.StartedAt)),
+			Status:      types.StringValue(e.Status),
+			VersionsNew: types.Int64Value(int64(e.VersionsNew)),
+		}
+		if e.CompletedAt != nil {
+			item.CompletedAt = types.StringValue(normalizeTimestamp(*e.CompletedAt))
+		} else {
+			item.CompletedAt = types.StringValue("")
+		}
+		if e.Message != nil {
+			item.Message = types.StringValue(*e.Message)
+		} else {
+			item.Message = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.History = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_terraform_mirror_version.go
+++ b/internal/provider/datasource_terraform_mirror_version.go
@@ -1,0 +1,134 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorVersionDataSource{}
+
+type TerraformMirrorVersionDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorVersionPlatformModel struct {
+	OS   types.String `tfsdk:"os"`
+	Arch types.String `tfsdk:"arch"`
+	URL  types.String `tfsdk:"url"`
+}
+
+type TerraformMirrorVersionDataSourceModel struct {
+	MirrorID  types.String                          `tfsdk:"mirror_id"`
+	Version   types.String                          `tfsdk:"version"`
+	ID        types.String                          `tfsdk:"id"`
+	Stable    types.Bool                            `tfsdk:"stable"`
+	SyncedAt  types.String                          `tfsdk:"synced_at"`
+	Platforms []TerraformMirrorVersionPlatformModel `tfsdk:"platforms"`
+}
+
+func NewTerraformMirrorVersionDataSource() datasource.DataSource {
+	return &TerraformMirrorVersionDataSource{}
+}
+
+func (d *TerraformMirrorVersionDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_version"
+}
+
+func (d *TerraformMirrorVersionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads details for a single mirrored Terraform/OpenTofu version including available platforms.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string to look up.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "Internal UUID of the version record.",
+				Computed:    true,
+			},
+			"stable": schema.BoolAttribute{
+				Description: "Whether this is a stable release.",
+				Computed:    true,
+			},
+			"synced_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when this version was synced.",
+				Computed:    true,
+			},
+			"platforms": schema.ListNestedAttribute{
+				Description: "Available platform builds for this version.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"os": schema.StringAttribute{
+							Description: "Operating system (e.g. 'linux', 'darwin').",
+							Computed:    true,
+						},
+						"arch": schema.StringAttribute{
+							Description: "Architecture (e.g. 'amd64', 'arm64').",
+							Computed:    true,
+						},
+						"url": schema.StringAttribute{
+							Description: "Download URL for this platform binary.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorVersionDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorVersionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorVersionDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	v, err := d.client.GetTerraformMirrorVersion(ctx, state.MirrorID.ValueString(), state.Version.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Terraform Mirror Version", err.Error())
+		return
+	}
+
+	state.ID = types.StringValue(v.ID)
+	state.Stable = types.BoolValue(v.Stable)
+	if v.SyncedAt != nil {
+		state.SyncedAt = types.StringValue(normalizeTimestamp(*v.SyncedAt))
+	} else {
+		state.SyncedAt = types.StringValue("")
+	}
+
+	platforms := make([]TerraformMirrorVersionPlatformModel, 0, len(v.Platforms))
+	for _, p := range v.Platforms {
+		platforms = append(platforms, TerraformMirrorVersionPlatformModel{
+			OS:   types.StringValue(p.OS),
+			Arch: types.StringValue(p.Arch),
+			URL:  types.StringValue(p.URL),
+		})
+	}
+	state.Platforms = platforms
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_terraform_mirror_versions.go
+++ b/internal/provider/datasource_terraform_mirror_versions.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorVersionsDataSource{}
+
+type TerraformMirrorVersionsDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorVersionsDataSourceModel struct {
+	MirrorID types.String                        `tfsdk:"mirror_id"`
+	Versions []TerraformMirrorVersionItemModel    `tfsdk:"versions"`
+}
+
+type TerraformMirrorVersionItemModel struct {
+	ID       types.String `tfsdk:"id"`
+	Version  types.String `tfsdk:"version"`
+	Stable   types.Bool   `tfsdk:"stable"`
+	SyncedAt types.String `tfsdk:"synced_at"`
+}
+
+func NewTerraformMirrorVersionsDataSource() datasource.DataSource {
+	return &TerraformMirrorVersionsDataSource{}
+}
+
+func (d *TerraformMirrorVersionsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_versions"
+}
+
+func (d *TerraformMirrorVersionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists all Terraform/OpenTofu versions mirrored by a given mirror configuration.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"versions": schema.ListNestedAttribute{
+				Description: "List of mirrored versions.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "Internal UUID of the version record.",
+							Computed:    true,
+						},
+						"version": schema.StringAttribute{
+							Description: "Semantic version string.",
+							Computed:    true,
+						},
+						"stable": schema.BoolAttribute{
+							Description: "Whether this is a stable release.",
+							Computed:    true,
+						},
+						"synced_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when this version was synced.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorVersionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorVersionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorVersionsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	versions, err := d.client.ListTerraformMirrorVersions(ctx, state.MirrorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Terraform Mirror Versions", err.Error())
+		return
+	}
+
+	items := make([]TerraformMirrorVersionItemModel, 0, len(versions))
+	for _, v := range versions {
+		item := TerraformMirrorVersionItemModel{
+			ID:      types.StringValue(v.ID),
+			Version: types.StringValue(v.Version),
+			Stable:  types.BoolValue(v.Stable),
+		}
+		if v.SyncedAt != nil {
+			item.SyncedAt = types.StringValue(normalizeTimestamp(*v.SyncedAt))
+		} else {
+			item.SyncedAt = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.Versions = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -182,6 +182,9 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewAuditLogsDataSource,
 		NewStatsDataSource,
 		NewOIDCConfigDataSource,
+		NewTerraformMirrorVersionsDataSource,
+		NewTerraformMirrorVersionDataSource,
+		NewTerraformMirrorHistoryDataSource,
 	}
 }
 


### PR DESCRIPTION
## Summary

- `data.registry_terraform_mirror_versions` — list all mirrored versions for a mirror config
- `data.registry_terraform_mirror_version` — single version detail including available platforms (os/arch/url)
- `data.registry_terraform_mirror_history` — sync history entries (started_at, completed_at, status, message, versions_new)

## Changelog
- feat: add `registry_terraform_mirror_versions`, `registry_terraform_mirror_version`, and `registry_terraform_mirror_history` data sources

Closes #27