### PR TITLE
feat: add registry_policy_engine_config and registry_policy_evaluation data sources

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,5 +1,26 @@
 package client
 
+// PolicyEngineConfig represents the rego policy engine bundle configuration.
+type PolicyEngineConfig struct {
+	BundleURL     string  `json:"bundle_url"`
+	BundleETag    *string `json:"bundle_etag,omitempty"`
+	LastLoadedAt  *string `json:"last_loaded_at,omitempty"`
+	Status        string  `json:"status"`
+}
+
+// PolicyEvaluateRequest is the payload for evaluating rego policy.
+type PolicyEvaluateRequest struct {
+	Input map[string]interface{} `json:"input"`
+	Query string                 `json:"query,omitempty"`
+}
+
+// PolicyEvaluateResult holds the result of a rego policy evaluation.
+type PolicyEvaluateResult struct {
+	Allowed bool                   `json:"allowed"`
+	Reason  *string                `json:"reason,omitempty"`
+	Result  map[string]interface{} `json:"result,omitempty"`
+}
+
 // OIDCConfig represents the backend OIDC configuration (read-only).
 type OIDCConfig struct {
 	Issuer         string   `json:"issuer"`

--- a/internal/client/policy_engine.go
+++ b/internal/client/policy_engine.go
@@ -1,0 +1,21 @@
+package client
+
+import "context"
+
+// GetPolicyEngineConfig fetches the rego bundle config via GET /api/v1/admin/policy/config.
+func (c *Client) GetPolicyEngineConfig(ctx context.Context) (*PolicyEngineConfig, error) {
+	var cfg PolicyEngineConfig
+	if err := c.Get(ctx, "/api/v1/admin/policy/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// EvaluatePolicy evaluates input against the rego bundle via POST /api/v1/admin/policy/evaluate.
+func (c *Client) EvaluatePolicy(ctx context.Context, req PolicyEvaluateRequest) (*PolicyEvaluateResult, error) {
+	var result PolicyEvaluateResult
+	if err := c.Post(ctx, "/api/v1/admin/policy/evaluate", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/provider/datasource_policy_engine_config.go
+++ b/internal/provider/datasource_policy_engine_config.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &PolicyEngineConfigDataSource{}
+
+type PolicyEngineConfigDataSource struct {
+	client *client.Client
+}
+
+type PolicyEngineConfigDataSourceModel struct {
+	BundleURL    types.String `tfsdk:"bundle_url"`
+	BundleETag   types.String `tfsdk:"bundle_etag"`
+	LastLoadedAt types.String `tfsdk:"last_loaded_at"`
+	Status       types.String `tfsdk:"status"`
+}
+
+func NewPolicyEngineConfigDataSource() datasource.DataSource {
+	return &PolicyEngineConfigDataSource{}
+}
+
+func (d *PolicyEngineConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_engine_config"
+}
+
+func (d *PolicyEngineConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the rego policy engine bundle configuration.",
+		Attributes: map[string]schema.Attribute{
+			"bundle_url": schema.StringAttribute{
+				Description: "URL from which the rego bundle is loaded.",
+				Computed:    true,
+			},
+			"bundle_etag": schema.StringAttribute{
+				Description: "ETag of the currently loaded bundle.",
+				Computed:    true,
+			},
+			"last_loaded_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the bundle was last loaded.",
+				Computed:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Bundle load status ('ok', 'error', etc.).",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *PolicyEngineConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *PolicyEngineConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetPolicyEngineConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Policy Engine Config", err.Error())
+		return
+	}
+
+	model := PolicyEngineConfigDataSourceModel{
+		BundleURL: types.StringValue(cfg.BundleURL),
+		Status:    types.StringValue(cfg.Status),
+	}
+	if cfg.BundleETag != nil {
+		model.BundleETag = types.StringValue(*cfg.BundleETag)
+	} else {
+		model.BundleETag = types.StringValue("")
+	}
+	if cfg.LastLoadedAt != nil {
+		model.LastLoadedAt = types.StringValue(normalizeTimestamp(*cfg.LastLoadedAt))
+	} else {
+		model.LastLoadedAt = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_policy_evaluation.go
+++ b/internal/provider/datasource_policy_evaluation.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &PolicyEvaluationDataSource{}
+
+type PolicyEvaluationDataSource struct {
+	client *client.Client
+}
+
+type PolicyEvaluationDataSourceModel struct {
+	InputJSON  types.String `tfsdk:"input_json"`
+	Query      types.String `tfsdk:"query"`
+	Allowed    types.Bool   `tfsdk:"allowed"`
+	Reason     types.String `tfsdk:"reason"`
+	ResultJSON types.String `tfsdk:"result_json"`
+}
+
+func NewPolicyEvaluationDataSource() datasource.DataSource {
+	return &PolicyEvaluationDataSource{}
+}
+
+func (d *PolicyEvaluationDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_evaluation"
+}
+
+func (d *PolicyEvaluationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Evaluates input against the rego policy bundle at plan time. Useful for policy-gating resource creation.",
+		Attributes: map[string]schema.Attribute{
+			"input_json": schema.StringAttribute{
+				Description: "JSON-encoded input document to evaluate against the policy bundle.",
+				Required:    true,
+			},
+			"query": schema.StringAttribute{
+				Description: "Optional rego query path (e.g. 'data.authz.allow'). Defaults to the bundle entry point if omitted.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"allowed": schema.BoolAttribute{
+				Description: "Whether the policy evaluation returned an allow decision.",
+				Computed:    true,
+			},
+			"reason": schema.StringAttribute{
+				Description: "Human-readable reason returned by the policy (if provided).",
+				Computed:    true,
+			},
+			"result_json": schema.StringAttribute{
+				Description: "Full policy result serialised as JSON.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *PolicyEvaluationDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *PolicyEvaluationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state PolicyEvaluationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input map[string]interface{}
+	if err := json.Unmarshal([]byte(state.InputJSON.ValueString()), &input); err != nil {
+		resp.Diagnostics.AddError("Invalid input_json", "input_json must be a valid JSON object: "+err.Error())
+		return
+	}
+
+	evalReq := client.PolicyEvaluateRequest{Input: input}
+	if !state.Query.IsNull() && !state.Query.IsUnknown() {
+		evalReq.Query = state.Query.ValueString()
+	}
+
+	result, err := d.client.EvaluatePolicy(ctx, evalReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Evaluating Policy", err.Error())
+		return
+	}
+
+	state.Allowed = types.BoolValue(result.Allowed)
+	if result.Reason != nil {
+		state.Reason = types.StringValue(*result.Reason)
+	} else {
+		state.Reason = types.StringValue("")
+	}
+	if state.Query.IsNull() || state.Query.IsUnknown() {
+		state.Query = types.StringValue("")
+	}
+
+	resultJSON := "{}"
+	if result.Result != nil {
+		if b, err := json.Marshal(result.Result); err == nil {
+			resultJSON = string(b)
+		}
+	}
+	state.ResultJSON = types.StringValue(resultJSON)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -185,6 +185,8 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewTerraformMirrorVersionsDataSource,
 		NewTerraformMirrorVersionDataSource,
 		NewTerraformMirrorHistoryDataSource,
+		NewPolicyEngineConfigDataSource,
+		NewPolicyEvaluationDataSource,
 	}
 }
 


### PR DESCRIPTION
## Summary

- `data.registry_policy_engine_config` — reads the rego bundle URL, ETag, load status, and last_loaded_at (reload endpoint intentionally omitted — it's an operational action)
- `data.registry_policy_evaluation` — evaluates an arbitrary `input_json` document against the bundle with an optional `query` path; returns `allowed`, `reason`, and `result_json` — useful for plan-time policy checks

## Changelog
- feat: add `registry_policy_engine_config` and `registry_policy_evaluation` data sources

Closes #29