### PR TITLE
feat: add registry_audit_log, registry_identity_group_mappings, and registry_mtls_config data sources

### DIFF
--- a/internal/client/audit_logs.go
+++ b/internal/client/audit_logs.go
@@ -45,6 +45,14 @@ func (c *Client) ListAuditLogs(ctx context.Context, action, resourceType string,
 	return logs, raw.Pagination.Total, nil
 }
 
+func (c *Client) GetAuditLog(ctx context.Context, id string) (*AuditLog, error) {
+	var l AuditLog
+	if err := c.Get(ctx, "/api/v1/admin/audit-logs/"+id, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
 func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
 	var resp struct {
 		Stats Stats `json:"stats"`

--- a/internal/client/identity.go
+++ b/internal/client/identity.go
@@ -1,0 +1,21 @@
+package client
+
+import "context"
+
+// GetIdentityGroupMappings fetches SAML/LDAP group → role mappings via GET /api/v1/admin/identity/group-mappings.
+func (c *Client) GetIdentityGroupMappings(ctx context.Context) ([]IdentityGroupMapping, error) {
+	var mappings []IdentityGroupMapping
+	if err := c.Get(ctx, "/api/v1/admin/identity/group-mappings", &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// GetMTLSConfig fetches the mTLS configuration via GET /api/v1/admin/mtls/config.
+func (c *Client) GetMTLSConfig(ctx context.Context) (*MTLSConfig, error) {
+	var cfg MTLSConfig
+	if err := c.Get(ctx, "/api/v1/admin/mtls/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -43,6 +43,20 @@ type PolicyEvaluateResult struct {
 	Result  map[string]interface{} `json:"result,omitempty"`
 }
 
+// IdentityGroupMapping represents a single SAML/LDAP group → role mapping.
+type IdentityGroupMapping struct {
+	Group          string `json:"group"`
+	OrganizationID string `json:"organization_id"`
+	RoleTemplateID string `json:"role_template_id"`
+}
+
+// MTLSConfig represents the backend mTLS certificate configuration.
+type MTLSConfig struct {
+	Enabled    bool    `json:"enabled"`
+	ClientCACN *string `json:"client_ca_cn,omitempty"`
+	ServerCert *string `json:"server_cert_subject,omitempty"`
+}
+
 // OIDCConfig represents the backend OIDC configuration (read-only).
 type OIDCConfig struct {
 	Issuer         string   `json:"issuer"`

--- a/internal/provider/datasource_audit_log.go
+++ b/internal/provider/datasource_audit_log.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &AuditLogDataSource{}
+
+type AuditLogDataSource struct {
+	client *client.Client
+}
+
+type AuditLogDataSourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	UserID         types.String `tfsdk:"user_id"`
+	UserEmail      types.String `tfsdk:"user_email"`
+	UserName       types.String `tfsdk:"user_name"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Action         types.String `tfsdk:"action"`
+	ResourceType   types.String `tfsdk:"resource_type"`
+	ResourceID     types.String `tfsdk:"resource_id"`
+	MetadataJSON   types.String `tfsdk:"metadata_json"`
+	IPAddress      types.String `tfsdk:"ip_address"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+}
+
+func NewAuditLogDataSource() datasource.DataSource {
+	return &AuditLogDataSource{}
+}
+
+func (d *AuditLogDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_audit_log"
+}
+
+func (d *AuditLogDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches a single audit log entry by UUID.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "UUID of the audit log entry to fetch.",
+				Required:    true,
+			},
+			"user_id": schema.StringAttribute{
+				Description: "UUID of the user who performed the action.",
+				Computed:    true,
+			},
+			"user_email": schema.StringAttribute{
+				Description: "Email of the user who performed the action.",
+				Computed:    true,
+			},
+			"user_name": schema.StringAttribute{
+				Description: "Display name of the user.",
+				Computed:    true,
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization context.",
+				Computed:    true,
+			},
+			"action": schema.StringAttribute{
+				Description: "Action performed (e.g. 'create', 'update', 'delete').",
+				Computed:    true,
+			},
+			"resource_type": schema.StringAttribute{
+				Description: "Type of resource affected.",
+				Computed:    true,
+			},
+			"resource_id": schema.StringAttribute{
+				Description: "UUID of the affected resource.",
+				Computed:    true,
+			},
+			"metadata_json": schema.StringAttribute{
+				Description: "Additional metadata serialised as JSON.",
+				Computed:    true,
+			},
+			"ip_address": schema.StringAttribute{
+				Description: "IP address of the requester.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp of the event.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *AuditLogDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *AuditLogDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state AuditLogDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	l, err := d.client.GetAuditLog(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Audit Log", err.Error())
+		return
+	}
+
+	state.Action = types.StringValue(l.Action)
+	state.CreatedAt = types.StringValue(normalizeTimestamp(l.CreatedAt))
+
+	setOptStr := func(dest *types.String, src *string) {
+		if src != nil {
+			*dest = types.StringValue(*src)
+		} else {
+			*dest = types.StringValue("")
+		}
+	}
+	setOptStr(&state.UserID, l.UserID)
+	setOptStr(&state.UserEmail, l.UserEmail)
+	setOptStr(&state.UserName, l.UserName)
+	setOptStr(&state.OrganizationID, l.OrganizationID)
+	setOptStr(&state.ResourceType, l.ResourceType)
+	setOptStr(&state.ResourceID, l.ResourceID)
+	setOptStr(&state.IPAddress, l.IPAddress)
+
+	metaJSON := "{}"
+	if l.Metadata != nil {
+		if b, err := json.Marshal(l.Metadata); err == nil {
+			metaJSON = string(b)
+		}
+	}
+	state.MetadataJSON = types.StringValue(metaJSON)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_identity_group_mappings.go
+++ b/internal/provider/datasource_identity_group_mappings.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &IdentityGroupMappingsDataSource{}
+
+type IdentityGroupMappingsDataSource struct {
+	client *client.Client
+}
+
+type IdentityGroupMappingItemModel struct {
+	Group          types.String `tfsdk:"group"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	RoleTemplateID types.String `tfsdk:"role_template_id"`
+}
+
+type IdentityGroupMappingsDataSourceModel struct {
+	Mappings []IdentityGroupMappingItemModel `tfsdk:"mappings"`
+}
+
+func NewIdentityGroupMappingsDataSource() datasource.DataSource {
+	return &IdentityGroupMappingsDataSource{}
+}
+
+func (d *IdentityGroupMappingsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_identity_group_mappings"
+}
+
+func (d *IdentityGroupMappingsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the SAML/LDAP group → organization role mappings from the backend runtime config (read-only).",
+		Attributes: map[string]schema.Attribute{
+			"mappings": schema.ListNestedAttribute{
+				Description: "List of identity group → role mappings.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"group": schema.StringAttribute{
+							Description: "SAML/LDAP group identifier.",
+							Computed:    true,
+						},
+						"organization_id": schema.StringAttribute{
+							Description: "UUID of the target organization.",
+							Computed:    true,
+						},
+						"role_template_id": schema.StringAttribute{
+							Description: "UUID of the role template assigned to members of this group.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *IdentityGroupMappingsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *IdentityGroupMappingsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	mappings, err := d.client.GetIdentityGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Identity Group Mappings", err.Error())
+		return
+	}
+
+	items := make([]IdentityGroupMappingItemModel, 0, len(mappings))
+	for _, m := range mappings {
+		items = append(items, IdentityGroupMappingItemModel{
+			Group:          types.StringValue(m.Group),
+			OrganizationID: types.StringValue(m.OrganizationID),
+			RoleTemplateID: types.StringValue(m.RoleTemplateID),
+		})
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, IdentityGroupMappingsDataSourceModel{Mappings: items})...)
+}

--- a/internal/provider/datasource_mtls_config.go
+++ b/internal/provider/datasource_mtls_config.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &MTLSConfigDataSource{}
+
+type MTLSConfigDataSource struct {
+	client *client.Client
+}
+
+type MTLSConfigDataSourceModel struct {
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	ClientCACN types.String `tfsdk:"client_ca_cn"`
+	ServerCert types.String `tfsdk:"server_cert_subject"`
+}
+
+func NewMTLSConfigDataSource() datasource.DataSource {
+	return &MTLSConfigDataSource{}
+}
+
+func (d *MTLSConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mtls_config"
+}
+
+func (d *MTLSConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend mTLS server certificate and CA configuration (read-only, sourced from backend startup config).",
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: "Whether mTLS is enabled on the backend.",
+				Computed:    true,
+			},
+			"client_ca_cn": schema.StringAttribute{
+				Description: "Common name of the client CA certificate.",
+				Computed:    true,
+			},
+			"server_cert_subject": schema.StringAttribute{
+				Description: "Subject of the server TLS certificate.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *MTLSConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *MTLSConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetMTLSConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading mTLS Config", err.Error())
+		return
+	}
+
+	model := MTLSConfigDataSourceModel{
+		Enabled: types.BoolValue(cfg.Enabled),
+	}
+	if cfg.ClientCACN != nil {
+		model.ClientCACN = types.StringValue(*cfg.ClientCACN)
+	} else {
+		model.ClientCACN = types.StringValue("")
+	}
+	if cfg.ServerCert != nil {
+		model.ServerCert = types.StringValue(*cfg.ServerCert)
+	} else {
+		model.ServerCert = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,6 +188,9 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewTerraformMirrorHistoryDataSource,
 		NewPolicyEngineConfigDataSource,
 		NewPolicyEvaluationDataSource,
+		NewAuditLogDataSource,
+		NewIdentityGroupMappingsDataSource,
+		NewMTLSConfigDataSource,
 	}
 }
 


### PR DESCRIPTION
## Summary

- `data.registry_audit_log` — fetches a single audit log entry by UUID; `metadata_json` exposes the freeform metadata map as a JSON string
- `data.registry_identity_group_mappings` — reads SAML/LDAP group → organization role mappings from the backend runtime config (read-only — sourced from startup config file, not DB)
- `data.registry_mtls_config` — reads mTLS enabled state, client CA CN, and server cert subject (read-only)

## Changelog
- feat: add `registry_audit_log` (singular) data source for fetching a single audit entry by id
- feat: add `registry_identity_group_mappings` and `registry_mtls_config` data sources

Closes #26
Closes #28