### PR TITLE
feat: add advisories and scanning data sources

### DIFF
--- a/internal/client/advisories.go
+++ b/internal/client/advisories.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListAdvisories fetches advisories from the admin endpoint.
+// If activeOnly is true it uses the public /active endpoint.
+func (c *Client) ListAdvisories(ctx context.Context, activeOnly bool, severities []string) ([]Advisory, error) {
+	var path string
+	if activeOnly {
+		path = "/api/v1/advisories/active"
+	} else {
+		path = "/api/v1/admin/advisories"
+	}
+
+	params := map[string]string{}
+	if len(severities) > 0 {
+		for _, s := range severities {
+			params["severity"] = s // last one wins; backend may accept repeated params
+		}
+	}
+	if len(params) > 0 {
+		path += BuildQuery(params)
+	}
+
+	items, err := FetchAllPages(ctx, c, path, "advisories")
+	if err != nil {
+		// Fall back: try as a flat array
+		var flat []Advisory
+		if err2 := c.Get(ctx, path, &flat); err2 == nil {
+			return flat, nil
+		}
+		return nil, err
+	}
+	advisories := make([]Advisory, 0, len(items))
+	for _, raw := range items {
+		var a Advisory
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, fmt.Errorf("unmarshaling advisory: %w", err)
+		}
+		advisories = append(advisories, a)
+	}
+	return advisories, nil
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -43,6 +43,65 @@ type PolicyEvaluateResult struct {
 	Result  map[string]interface{} `json:"result,omitempty"`
 }
 
+// Advisory represents a CVE or security advisory entry.
+type Advisory struct {
+	ID          string  `json:"id"`
+	ExternalID  string  `json:"external_id"`
+	Title       string  `json:"title"`
+	Description *string `json:"description,omitempty"`
+	Severity    string  `json:"severity"`
+	URL         *string `json:"url,omitempty"`
+	PublishedAt *string `json:"published_at,omitempty"`
+	ResolvedAt  *string `json:"resolved_at,omitempty"`
+	Active      bool    `json:"active"`
+}
+
+// ScanningConfig represents the backend scanner tool configuration.
+type ScanningConfig struct {
+	Enabled         bool     `json:"enabled"`
+	BinaryPath      *string  `json:"binary_path,omitempty"`
+	DetectedVersion *string  `json:"detected_version,omitempty"`
+	EnabledTools    []string `json:"enabled_tools"`
+}
+
+// ScanningStats represents aggregate scan statistics.
+type ScanningStats struct {
+	TotalScans     int `json:"total_scans"`
+	PassedScans    int `json:"passed_scans"`
+	FailedScans    int `json:"failed_scans"`
+	PendingScans   int `json:"pending_scans"`
+	TotalFindings  int `json:"total_findings"`
+	CriticalCount  int `json:"critical_count"`
+	HighCount      int `json:"high_count"`
+	MediumCount    int `json:"medium_count"`
+	LowCount       int `json:"low_count"`
+}
+
+// ScanFinding represents a single security finding in a scan.
+type ScanFinding struct {
+	ID          string  `json:"id"`
+	RuleID      string  `json:"rule_id"`
+	Severity    string  `json:"severity"`
+	Title       string  `json:"title"`
+	Description *string `json:"description,omitempty"`
+	Resource    *string `json:"resource,omitempty"`
+	FilePath    *string `json:"file_path,omitempty"`
+	LineNumber  *int    `json:"line_number,omitempty"`
+}
+
+// Scan represents a security scan result.
+type Scan struct {
+	ID             string        `json:"id"`
+	Status         string        `json:"status"`
+	Scanner        string        `json:"scanner"`
+	Passed         bool          `json:"passed"`
+	Findings       []ScanFinding `json:"findings,omitempty"`
+	ExecutionLog   *string       `json:"execution_log,omitempty"`
+	StartedAt      *string       `json:"started_at,omitempty"`
+	CompletedAt    *string       `json:"completed_at,omitempty"`
+	CreatedAt      string        `json:"created_at"`
+}
+
 // IdentityGroupMapping represents a single SAML/LDAP group → role mapping.
 type IdentityGroupMapping struct {
 	Group          string `json:"group"`

--- a/internal/client/scanning.go
+++ b/internal/client/scanning.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetScanningConfig fetches the scanner configuration via GET /api/v1/admin/scanning/config.
+func (c *Client) GetScanningConfig(ctx context.Context) (*ScanningConfig, error) {
+	var cfg ScanningConfig
+	if err := c.Get(ctx, "/api/v1/admin/scanning/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// GetScanningStats fetches aggregate scan statistics via GET /api/v1/admin/scanning/stats.
+func (c *Client) GetScanningStats(ctx context.Context) (*ScanningStats, error) {
+	var stats ScanningStats
+	if err := c.Get(ctx, "/api/v1/admin/scanning/stats", &stats); err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+// GetScan fetches a scan by UUID via GET /api/v1/admin/scanning/scans/{id}.
+func (c *Client) GetScan(ctx context.Context, id string) (*Scan, error) {
+	var s Scan
+	if err := c.Get(ctx, "/api/v1/admin/scanning/scans/"+id, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// GetModuleScan fetches the most recent scan for a module version.
+func (c *Client) GetModuleScan(ctx context.Context, namespace, name, system, version string) (*Scan, error) {
+	var s Scan
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/scan", namespace, name, system, version)
+	if err := c.Get(ctx, path, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/provider/datasource_advisories.go
+++ b/internal/provider/datasource_advisories.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &AdvisoriesDataSource{}
+
+type AdvisoriesDataSource struct {
+	client *client.Client
+}
+
+type AdvisoryItemModel struct {
+	ID          types.String `tfsdk:"id"`
+	ExternalID  types.String `tfsdk:"external_id"`
+	Title       types.String `tfsdk:"title"`
+	Description types.String `tfsdk:"description"`
+	Severity    types.String `tfsdk:"severity"`
+	URL         types.String `tfsdk:"url"`
+	PublishedAt types.String `tfsdk:"published_at"`
+	ResolvedAt  types.String `tfsdk:"resolved_at"`
+	Active      types.Bool   `tfsdk:"active"`
+}
+
+type AdvisoriesDataSourceModel struct {
+	ActiveOnly types.Bool          `tfsdk:"active_only"`
+	Severities types.List          `tfsdk:"severities"`
+	Advisories []AdvisoryItemModel `tfsdk:"advisories"`
+}
+
+func NewAdvisoriesDataSource() datasource.DataSource {
+	return &AdvisoriesDataSource{}
+}
+
+func (d *AdvisoriesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_advisories"
+}
+
+func (d *AdvisoriesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists CVE security advisories from the registry. Use active_only = true to restrict to currently active advisories.",
+		Attributes: map[string]schema.Attribute{
+			"active_only": schema.BoolAttribute{
+				Description: "If true, only returns currently active advisories. Defaults to false (returns all).",
+				Optional:    true,
+			},
+			"severities": schema.ListAttribute{
+				Description: "Optional list of severity values to filter by (e.g. ['high', 'critical']).",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"advisories": schema.ListNestedAttribute{
+				Description: "List of matching advisories.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id":          schema.StringAttribute{Description: "Internal UUID.", Computed: true},
+						"external_id": schema.StringAttribute{Description: "CVE identifier (e.g. CVE-2024-12345).", Computed: true},
+						"title":       schema.StringAttribute{Description: "Advisory title.", Computed: true},
+						"description": schema.StringAttribute{Description: "Advisory description.", Computed: true},
+						"severity":    schema.StringAttribute{Description: "Severity level.", Computed: true},
+						"url":         schema.StringAttribute{Description: "Reference URL.", Computed: true},
+						"published_at": schema.StringAttribute{Description: "ISO 8601 publish timestamp.", Computed: true},
+						"resolved_at":  schema.StringAttribute{Description: "ISO 8601 resolution timestamp (empty if unresolved).", Computed: true},
+						"active":      schema.BoolAttribute{Description: "Whether the advisory is currently active.", Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *AdvisoriesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *AdvisoriesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state AdvisoriesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	activeOnly := !state.ActiveOnly.IsNull() && !state.ActiveOnly.IsUnknown() && state.ActiveOnly.ValueBool()
+
+	var severities []string
+	if !state.Severities.IsNull() && !state.Severities.IsUnknown() {
+		resp.Diagnostics.Append(state.Severities.ElementsAs(ctx, &severities, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	advisories, err := d.client.ListAdvisories(ctx, activeOnly, severities)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Advisories", err.Error())
+		return
+	}
+
+	items := make([]AdvisoryItemModel, 0, len(advisories))
+	for _, a := range advisories {
+		item := AdvisoryItemModel{
+			ID:         types.StringValue(a.ID),
+			ExternalID: types.StringValue(a.ExternalID),
+			Title:      types.StringValue(a.Title),
+			Severity:   types.StringValue(a.Severity),
+			Active:     types.BoolValue(a.Active),
+		}
+		optStr := func(s *string) types.String {
+			if s != nil {
+				return types.StringValue(*s)
+			}
+			return types.StringValue("")
+		}
+		item.Description = optStr(a.Description)
+		item.URL = optStr(a.URL)
+		if a.PublishedAt != nil {
+			item.PublishedAt = types.StringValue(normalizeTimestamp(*a.PublishedAt))
+		} else {
+			item.PublishedAt = types.StringValue("")
+		}
+		if a.ResolvedAt != nil {
+			item.ResolvedAt = types.StringValue(normalizeTimestamp(*a.ResolvedAt))
+		} else {
+			item.ResolvedAt = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.Advisories = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_scan.go
+++ b/internal/provider/datasource_scan.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanDataSource{}
+
+type ScanDataSource struct {
+	client *client.Client
+}
+
+type ScanDataSourceModel struct {
+	ScanDataModel
+}
+
+func NewScanDataSource() datasource.DataSource {
+	return &ScanDataSource{}
+}
+
+func (d *ScanDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scan"
+}
+
+func (d *ScanDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches a single security scan by UUID.",
+		Attributes:  scanResultSchema(),
+	}
+}
+
+func (d *ScanDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ScanDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	s, err := d.client.GetScan(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scan", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, ScanDataSourceModel{scanToModel(s)})...)
+}
+
+// scanResultSchema returns the shared schema for scan result attributes.
+func scanResultSchema() map[string]schema.Attribute {
+	findingAttrs := schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"id":          schema.StringAttribute{Description: "UUID of the finding.", Computed: true},
+			"rule_id":     schema.StringAttribute{Description: "Rule identifier.", Computed: true},
+			"severity":    schema.StringAttribute{Description: "Finding severity.", Computed: true},
+			"title":       schema.StringAttribute{Description: "Finding title.", Computed: true},
+			"description": schema.StringAttribute{Description: "Finding description.", Computed: true},
+			"resource":    schema.StringAttribute{Description: "Affected resource name.", Computed: true},
+			"file_path":   schema.StringAttribute{Description: "Source file path.", Computed: true},
+			"line_number": schema.Int64Attribute{Description: "Line number in the source file.", Computed: true},
+		},
+	}
+	return map[string]schema.Attribute{
+		"id":            schema.StringAttribute{Description: "UUID of the scan (required for registry_scan; computed for registry_module_scan).", Optional: true, Computed: true},
+		"status":        schema.StringAttribute{Description: "Scan status.", Computed: true},
+		"scanner":       schema.StringAttribute{Description: "Scanner tool name.", Computed: true},
+		"passed":        schema.BoolAttribute{Description: "Whether the scan passed.", Computed: true},
+		"execution_log": schema.StringAttribute{Description: "Raw scanner output.", Computed: true},
+		"started_at":    schema.StringAttribute{Description: "ISO 8601 start timestamp.", Computed: true},
+		"completed_at":  schema.StringAttribute{Description: "ISO 8601 completion timestamp.", Computed: true},
+		"created_at":    schema.StringAttribute{Description: "ISO 8601 creation timestamp.", Computed: true},
+		"findings": schema.ListNestedAttribute{
+			Description:  "Security findings from the scan.",
+			Computed:     true,
+			NestedObject: findingAttrs,
+		},
+	}
+}
+
+// moduleScanSchema extends scanResultSchema with module-addressing attributes.
+func moduleScanSchema() map[string]schema.Attribute {
+	attrs := scanResultSchema()
+	attrs["namespace"] = schema.StringAttribute{Description: "Module namespace.", Required: true}
+	attrs["name"] = schema.StringAttribute{Description: "Module name.", Required: true}
+	attrs["system"] = schema.StringAttribute{Description: "Module system.", Required: true}
+	attrs["version"] = schema.StringAttribute{Description: "Module version.", Required: true}
+	// id is computed only for module scan (not required)
+	delete(attrs, "id")
+	attrs["id"] = schema.StringAttribute{Description: "UUID of the scan.", Computed: true}
+	return attrs
+}
+
+// ModuleScanDataSource fetches the most recent scan for a module version.
+type ModuleScanDataSource struct {
+	client *client.Client
+}
+
+var _ datasource.DataSource = &ModuleScanDataSource{}
+
+type ModuleScanDataSourceModel struct {
+	Namespace types.String `tfsdk:"namespace"`
+	Name      types.String `tfsdk:"name"`
+	System    types.String `tfsdk:"system"`
+	Version   types.String `tfsdk:"version"`
+	ScanDataModel
+}
+
+func NewModuleScanDataSource() datasource.DataSource {
+	return &ModuleScanDataSource{}
+}
+
+func (d *ModuleScanDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_scan"
+}
+
+func (d *ModuleScanDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches the most recent security scan result for a specific module version.",
+		Attributes:  moduleScanSchema(),
+	}
+}
+
+func (d *ModuleScanDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ModuleScanDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ModuleScanDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	s, err := d.client.GetModuleScan(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Module Scan", err.Error())
+		return
+	}
+
+	scanModel := scanToModel(s)
+	result := ModuleScanDataSourceModel{
+		Namespace:     state.Namespace,
+		Name:          state.Name,
+		System:        state.System,
+		Version:       state.Version,
+		ScanDataModel: scanModel,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+}

--- a/internal/provider/datasource_scanning_config.go
+++ b/internal/provider/datasource_scanning_config.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanningConfigDataSource{}
+
+type ScanningConfigDataSource struct {
+	client *client.Client
+}
+
+type ScanningConfigDataSourceModel struct {
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	BinaryPath      types.String `tfsdk:"binary_path"`
+	DetectedVersion types.String `tfsdk:"detected_version"`
+	EnabledTools    types.List   `tfsdk:"enabled_tools"`
+}
+
+func NewScanningConfigDataSource() datasource.DataSource {
+	return &ScanningConfigDataSource{}
+}
+
+func (d *ScanningConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scanning_config"
+}
+
+func (d *ScanningConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend security scanner configuration.",
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: "Whether security scanning is enabled.",
+				Computed:    true,
+			},
+			"binary_path": schema.StringAttribute{
+				Description: "Path to the scanner binary.",
+				Computed:    true,
+			},
+			"detected_version": schema.StringAttribute{
+				Description: "Detected scanner version string.",
+				Computed:    true,
+			},
+			"enabled_tools": schema.ListAttribute{
+				Description: "List of enabled scanning tools.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *ScanningConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanningConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetScanningConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scanning Config", err.Error())
+		return
+	}
+
+	tools, diags := types.ListValueFrom(ctx, types.StringType, cfg.EnabledTools)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	model := ScanningConfigDataSourceModel{
+		Enabled:      types.BoolValue(cfg.Enabled),
+		EnabledTools: tools,
+	}
+	if cfg.BinaryPath != nil {
+		model.BinaryPath = types.StringValue(*cfg.BinaryPath)
+	} else {
+		model.BinaryPath = types.StringValue("")
+	}
+	if cfg.DetectedVersion != nil {
+		model.DetectedVersion = types.StringValue(*cfg.DetectedVersion)
+	} else {
+		model.DetectedVersion = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_scanning_stats.go
+++ b/internal/provider/datasource_scanning_stats.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanningStatsDataSource{}
+
+type ScanningStatsDataSource struct {
+	client *client.Client
+}
+
+type ScanningStatsDataSourceModel struct {
+	TotalScans    types.Int64 `tfsdk:"total_scans"`
+	PassedScans   types.Int64 `tfsdk:"passed_scans"`
+	FailedScans   types.Int64 `tfsdk:"failed_scans"`
+	PendingScans  types.Int64 `tfsdk:"pending_scans"`
+	TotalFindings types.Int64 `tfsdk:"total_findings"`
+	CriticalCount types.Int64 `tfsdk:"critical_count"`
+	HighCount     types.Int64 `tfsdk:"high_count"`
+	MediumCount   types.Int64 `tfsdk:"medium_count"`
+	LowCount      types.Int64 `tfsdk:"low_count"`
+}
+
+func NewScanningStatsDataSource() datasource.DataSource {
+	return &ScanningStatsDataSource{}
+}
+
+func (d *ScanningStatsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scanning_stats"
+}
+
+func (d *ScanningStatsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads aggregate security scan statistics.",
+		Attributes: map[string]schema.Attribute{
+			"total_scans":    schema.Int64Attribute{Description: "Total number of scans.", Computed: true},
+			"passed_scans":   schema.Int64Attribute{Description: "Number of scans that passed.", Computed: true},
+			"failed_scans":   schema.Int64Attribute{Description: "Number of scans that failed.", Computed: true},
+			"pending_scans":  schema.Int64Attribute{Description: "Number of scans pending or running.", Computed: true},
+			"total_findings": schema.Int64Attribute{Description: "Total findings across all scans.", Computed: true},
+			"critical_count": schema.Int64Attribute{Description: "Critical severity findings.", Computed: true},
+			"high_count":     schema.Int64Attribute{Description: "High severity findings.", Computed: true},
+			"medium_count":   schema.Int64Attribute{Description: "Medium severity findings.", Computed: true},
+			"low_count":      schema.Int64Attribute{Description: "Low severity findings.", Computed: true},
+		},
+	}
+}
+
+func (d *ScanningStatsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanningStatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	stats, err := d.client.GetScanningStats(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scanning Stats", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, ScanningStatsDataSourceModel{
+		TotalScans:    types.Int64Value(int64(stats.TotalScans)),
+		PassedScans:   types.Int64Value(int64(stats.PassedScans)),
+		FailedScans:   types.Int64Value(int64(stats.FailedScans)),
+		PendingScans:  types.Int64Value(int64(stats.PendingScans)),
+		TotalFindings: types.Int64Value(int64(stats.TotalFindings)),
+		CriticalCount: types.Int64Value(int64(stats.CriticalCount)),
+		HighCount:     types.Int64Value(int64(stats.HighCount)),
+		MediumCount:   types.Int64Value(int64(stats.MediumCount)),
+		LowCount:      types.Int64Value(int64(stats.LowCount)),
+	})...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,6 +191,11 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewAuditLogDataSource,
 		NewIdentityGroupMappingsDataSource,
 		NewMTLSConfigDataSource,
+		NewAdvisoriesDataSource,
+		NewScanningConfigDataSource,
+		NewScanningStatsDataSource,
+		NewScanDataSource,
+		NewModuleScanDataSource,
 	}
 }
 

--- a/internal/provider/scan_model.go
+++ b/internal/provider/scan_model.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+// ScanFindingModel is the Terraform model for a scan finding.
+type ScanFindingModel struct {
+	ID          types.String `tfsdk:"id"`
+	RuleID      types.String `tfsdk:"rule_id"`
+	Severity    types.String `tfsdk:"severity"`
+	Title       types.String `tfsdk:"title"`
+	Description types.String `tfsdk:"description"`
+	Resource    types.String `tfsdk:"resource"`
+	FilePath    types.String `tfsdk:"file_path"`
+	LineNumber  types.Int64  `tfsdk:"line_number"`
+}
+
+// ScanDataModel holds the common attributes of a scan result.
+type ScanDataModel struct {
+	ID           types.String       `tfsdk:"id"`
+	Status       types.String       `tfsdk:"status"`
+	Scanner      types.String       `tfsdk:"scanner"`
+	Passed       types.Bool         `tfsdk:"passed"`
+	Findings     []ScanFindingModel `tfsdk:"findings"`
+	ExecutionLog types.String       `tfsdk:"execution_log"`
+	StartedAt    types.String       `tfsdk:"started_at"`
+	CompletedAt  types.String       `tfsdk:"completed_at"`
+	CreatedAt    types.String       `tfsdk:"created_at"`
+}
+
+func scanToModel(s *client.Scan) ScanDataModel {
+	m := ScanDataModel{
+		ID:        types.StringValue(s.ID),
+		Status:    types.StringValue(s.Status),
+		Scanner:   types.StringValue(s.Scanner),
+		Passed:    types.BoolValue(s.Passed),
+		CreatedAt: types.StringValue(normalizeTimestamp(s.CreatedAt)),
+	}
+	if s.ExecutionLog != nil {
+		m.ExecutionLog = types.StringValue(*s.ExecutionLog)
+	} else {
+		m.ExecutionLog = types.StringValue("")
+	}
+	if s.StartedAt != nil {
+		m.StartedAt = types.StringValue(normalizeTimestamp(*s.StartedAt))
+	} else {
+		m.StartedAt = types.StringValue("")
+	}
+	if s.CompletedAt != nil {
+		m.CompletedAt = types.StringValue(normalizeTimestamp(*s.CompletedAt))
+	} else {
+		m.CompletedAt = types.StringValue("")
+	}
+
+	findings := make([]ScanFindingModel, 0, len(s.Findings))
+	for _, f := range s.Findings {
+		fm := ScanFindingModel{
+			ID:       types.StringValue(f.ID),
+			RuleID:   types.StringValue(f.RuleID),
+			Severity: types.StringValue(f.Severity),
+			Title:    types.StringValue(f.Title),
+		}
+		opt := func(s *string) types.String {
+			if s != nil {
+				return types.StringValue(*s)
+			}
+			return types.StringValue("")
+		}
+		fm.Description = opt(f.Description)
+		fm.Resource = opt(f.Resource)
+		fm.FilePath = opt(f.FilePath)
+		if f.LineNumber != nil {
+			fm.LineNumber = types.Int64Value(int64(*f.LineNumber))
+		} else {
+			fm.LineNumber = types.Int64Value(0)
+		}
+		findings = append(findings, fm)
+	}
+	m.Findings = findings
+	return m
+}


### PR DESCRIPTION
## Summary

- `data.registry_advisories` — lists CVE advisories; `active_only` uses the public `/active` endpoint, optional `severities` filter
- `data.registry_scanning_config` — scanner tool config (enabled, binary_path, detected_version, enabled_tools)
- `data.registry_scanning_stats` — aggregate scan counters (total, passed, failed, pending, findings by severity)
- `data.registry_scan` — single scan by UUID including findings and execution_log
- `data.registry_module_scan` — most recent scan for a module version

## Changelog
- feat: add `registry_advisories` data source for CVE advisory feed
- feat: add `registry_scanning_config`, `registry_scanning_stats`, `registry_module_scan`, `registry_scan` data sources

Closes #24
Closes #22