### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-05-05
+
+### Added
+
+- `registry_module_deprecation` — marks a module as deprecated; `message` and optional `successor_module_id`; destroy removes the deprecation (#54)
+- `registry_module_version_deprecation` — marks a specific module version as deprecated; supports `replacement_source` for Terraform CLI ≥1.10 upgrade guidance (#54)
+- `registry_provider_version_deprecation` — marks a specific provider version as deprecated (#54)
+- `registry_oidc_group_mapping` — manages a single OIDC group → organization role mapping (read-modify-write against full-replace backend endpoint) (#55)
+- `data.registry_oidc_config` — reads OIDC issuer, client_id, scopes, groups_claim, username_claim (#55)
+- `registry_storage_migration` — triggers a one-shot storage backend migration with configurable `timeout_minutes` (default 60) and progress counters; destroy cancels if still running (#58)
+- `registry_module_reanalyze` — trigger-pattern resource that re-runs terraform-docs / scanning / SCM verification on a module version; recreates when `triggers` map changes (#61)
+- `data.registry_terraform_mirror_versions` — list all mirrored Terraform/OpenTofu versions for a mirror config (#56)
+- `data.registry_terraform_mirror_version` — single version detail including available platforms (#56)
+- `data.registry_terraform_mirror_history` — sync history entries for a mirror (#56)
+- `data.registry_policy_engine_config` — reads rego bundle URL, ETag, status, and last_loaded_at (#57)
+- `data.registry_policy_evaluation` — evaluates `input_json` against the rego bundle at plan time; returns `allowed`, `reason`, `result_json` (#57)
+- `data.registry_audit_log` — fetches a single audit log entry by UUID with `metadata_json` (#59)
+- `data.registry_identity_group_mappings` — reads SAML/LDAP group → role mappings from backend runtime config (#59)
+- `data.registry_mtls_config` — reads mTLS enabled state, client CA CN, and server cert subject (#59)
+- `data.registry_advisories` — lists CVE advisories with `active_only` and `severities` filters (#60)
+- `data.registry_scanning_config` — scanner tool configuration (enabled, binary_path, detected_version, enabled_tools) (#60)
+- `data.registry_scanning_stats` — aggregate scan statistics by severity (#60)
+- `data.registry_scan` — fetches a single security scan by UUID including findings and execution_log (#60)
+- `data.registry_module_scan` — fetches the most recent scan for a specific module version (#60)
+- Provider now probes `GET /version` on configure and emits a warning diagnostic if the backend is older than the minimum supported version (`1.0.0`); opt out with `version_check = false` (#53)
+
+### Changed
+
+- `deployments/docker-compose.test.yml` backend image pinned from `latest` to `v1.0.0`; pin policy documented in CONTRIBUTING (#52)
+
+---
+
 ## [0.2.1] - 2026-05-04
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,11 @@ go test -v -count=1 ./internal/client/...
 
 For changes that affect provider behaviour, run the acceptance tests too:
 
+The test stack in `deployments/docker-compose.test.yml` pins the backend image to a specific
+version tag (e.g. `ghcr.io/sethbacon/terraform-registry-backend:v1.0.0`). Bump this pin in
+lockstep with backend major releases; otherwise leave it at the current pinned tag so that
+acceptance tests run against a known-good backend rather than a moving `latest`.
+
 ```bash
 # Start the test backend
 docker compose -f deployments/docker-compose.test.yml up -d

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
       retries: 15
 
   backend:
-    image: ghcr.io/sethbacon/terraform-registry-backend:latest
+    image: ghcr.io/sethbacon/terraform-registry-backend:v1.0.0
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432

--- a/internal/client/advisories.go
+++ b/internal/client/advisories.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListAdvisories fetches advisories from the admin endpoint.
+// If activeOnly is true it uses the public /active endpoint.
+func (c *Client) ListAdvisories(ctx context.Context, activeOnly bool, severities []string) ([]Advisory, error) {
+	var path string
+	if activeOnly {
+		path = "/api/v1/advisories/active"
+	} else {
+		path = "/api/v1/admin/advisories"
+	}
+
+	params := map[string]string{}
+	if len(severities) > 0 {
+		for _, s := range severities {
+			params["severity"] = s // last one wins; backend may accept repeated params
+		}
+	}
+	if len(params) > 0 {
+		path += BuildQuery(params)
+	}
+
+	items, err := FetchAllPages(ctx, c, path, "advisories")
+	if err != nil {
+		// Fall back: try as a flat array
+		var flat []Advisory
+		if err2 := c.Get(ctx, path, &flat); err2 == nil {
+			return flat, nil
+		}
+		return nil, err
+	}
+	advisories := make([]Advisory, 0, len(items))
+	for _, raw := range items {
+		var a Advisory
+		if err := json.Unmarshal(raw, &a); err != nil {
+			return nil, fmt.Errorf("unmarshaling advisory: %w", err)
+		}
+		advisories = append(advisories, a)
+	}
+	return advisories, nil
+}

--- a/internal/client/audit_logs.go
+++ b/internal/client/audit_logs.go
@@ -45,6 +45,14 @@ func (c *Client) ListAuditLogs(ctx context.Context, action, resourceType string,
 	return logs, raw.Pagination.Total, nil
 }
 
+func (c *Client) GetAuditLog(ctx context.Context, id string) (*AuditLog, error) {
+	var l AuditLog
+	if err := c.Get(ctx, "/api/v1/admin/audit-logs/"+id, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
 func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
 	var resp struct {
 		Stats Stats `json:"stats"`

--- a/internal/client/identity.go
+++ b/internal/client/identity.go
@@ -1,0 +1,21 @@
+package client
+
+import "context"
+
+// GetIdentityGroupMappings fetches SAML/LDAP group → role mappings via GET /api/v1/admin/identity/group-mappings.
+func (c *Client) GetIdentityGroupMappings(ctx context.Context) ([]IdentityGroupMapping, error) {
+	var mappings []IdentityGroupMapping
+	if err := c.Get(ctx, "/api/v1/admin/identity/group-mappings", &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// GetMTLSConfig fetches the mTLS configuration via GET /api/v1/admin/mtls/config.
+func (c *Client) GetMTLSConfig(ctx context.Context) (*MTLSConfig, error) {
+	var cfg MTLSConfig
+	if err := c.Get(ctx, "/api/v1/admin/mtls/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,5 +1,27 @@
 package client
 
+// StorageMigration represents a storage migration job.
+type StorageMigration struct {
+	ID              string  `json:"id"`
+	SourceConfigID  string  `json:"source_config_id"`
+	TargetConfigID  string  `json:"target_config_id"`
+	Status          string  `json:"status"`
+	ObjectsTotal    int     `json:"objects_total"`
+	ObjectsMigrated int     `json:"objects_migrated"`
+	ObjectsFailed   int     `json:"objects_failed"`
+	StartedAt       *string `json:"started_at,omitempty"`
+	CompletedAt     *string `json:"completed_at,omitempty"`
+	Error           *string `json:"error,omitempty"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+// CreateStorageMigrationRequest is the payload for starting a migration.
+type CreateStorageMigrationRequest struct {
+	SourceConfigID string `json:"source_config_id"`
+	TargetConfigID string `json:"target_config_id"`
+}
+
 // PolicyEngineConfig represents the rego policy engine bundle configuration.
 type PolicyEngineConfig struct {
 	BundleURL     string  `json:"bundle_url"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,5 +1,26 @@
 package client
 
+// PolicyEngineConfig represents the rego policy engine bundle configuration.
+type PolicyEngineConfig struct {
+	BundleURL     string  `json:"bundle_url"`
+	BundleETag    *string `json:"bundle_etag,omitempty"`
+	LastLoadedAt  *string `json:"last_loaded_at,omitempty"`
+	Status        string  `json:"status"`
+}
+
+// PolicyEvaluateRequest is the payload for evaluating rego policy.
+type PolicyEvaluateRequest struct {
+	Input map[string]interface{} `json:"input"`
+	Query string                 `json:"query,omitempty"`
+}
+
+// PolicyEvaluateResult holds the result of a rego policy evaluation.
+type PolicyEvaluateResult struct {
+	Allowed bool                   `json:"allowed"`
+	Reason  *string                `json:"reason,omitempty"`
+	Result  map[string]interface{} `json:"result,omitempty"`
+}
+
 // OIDCConfig represents the backend OIDC configuration (read-only).
 type OIDCConfig struct {
 	Issuer         string   `json:"issuer"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -43,6 +43,20 @@ type PolicyEvaluateResult struct {
 	Result  map[string]interface{} `json:"result,omitempty"`
 }
 
+// IdentityGroupMapping represents a single SAML/LDAP group → role mapping.
+type IdentityGroupMapping struct {
+	Group          string `json:"group"`
+	OrganizationID string `json:"organization_id"`
+	RoleTemplateID string `json:"role_template_id"`
+}
+
+// MTLSConfig represents the backend mTLS certificate configuration.
+type MTLSConfig struct {
+	Enabled    bool    `json:"enabled"`
+	ClientCACN *string `json:"client_ca_cn,omitempty"`
+	ServerCert *string `json:"server_cert_subject,omitempty"`
+}
+
 // OIDCConfig represents the backend OIDC configuration (read-only).
 type OIDCConfig struct {
 	Issuer         string   `json:"issuer"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -164,6 +164,37 @@ type UpdateModuleRequest struct {
 	Source      *string `json:"source,omitempty"`
 }
 
+// ModuleVersion represents a single version of a registry module.
+type ModuleVersion struct {
+	ID                 string  `json:"id"`
+	Version            string  `json:"version"`
+	Deprecated         bool    `json:"deprecated"`
+	DeprecatedAt       *string `json:"deprecated_at,omitempty"`
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+	ReplacementSource  *string `json:"replacement_source,omitempty"`
+}
+
+// DeprecateModuleRequest is the payload for deprecating a module or module version.
+type DeprecateModuleRequest struct {
+	Message           string  `json:"message"`
+	SuccessorModuleID *string `json:"successor_module_id,omitempty"`
+	ReplacementSource *string `json:"replacement_source,omitempty"`
+}
+
+// ProviderVersion represents a single version of a registry provider.
+type ProviderVersion struct {
+	ID                 string  `json:"id"`
+	Version            string  `json:"version"`
+	Deprecated         bool    `json:"deprecated"`
+	DeprecatedAt       *string `json:"deprecated_at,omitempty"`
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+}
+
+// DeprecateProviderVersionRequest is the payload for deprecating a provider version.
+type DeprecateProviderVersionRequest struct {
+	Message string `json:"message"`
+}
+
 // ProviderRecord represents a registry provider record.
 type ProviderRecord struct {
 	ID             string  `json:"id"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -43,6 +43,65 @@ type PolicyEvaluateResult struct {
 	Result  map[string]interface{} `json:"result,omitempty"`
 }
 
+// Advisory represents a CVE or security advisory entry.
+type Advisory struct {
+	ID          string  `json:"id"`
+	ExternalID  string  `json:"external_id"`
+	Title       string  `json:"title"`
+	Description *string `json:"description,omitempty"`
+	Severity    string  `json:"severity"`
+	URL         *string `json:"url,omitempty"`
+	PublishedAt *string `json:"published_at,omitempty"`
+	ResolvedAt  *string `json:"resolved_at,omitempty"`
+	Active      bool    `json:"active"`
+}
+
+// ScanningConfig represents the backend scanner tool configuration.
+type ScanningConfig struct {
+	Enabled         bool     `json:"enabled"`
+	BinaryPath      *string  `json:"binary_path,omitempty"`
+	DetectedVersion *string  `json:"detected_version,omitempty"`
+	EnabledTools    []string `json:"enabled_tools"`
+}
+
+// ScanningStats represents aggregate scan statistics.
+type ScanningStats struct {
+	TotalScans     int `json:"total_scans"`
+	PassedScans    int `json:"passed_scans"`
+	FailedScans    int `json:"failed_scans"`
+	PendingScans   int `json:"pending_scans"`
+	TotalFindings  int `json:"total_findings"`
+	CriticalCount  int `json:"critical_count"`
+	HighCount      int `json:"high_count"`
+	MediumCount    int `json:"medium_count"`
+	LowCount       int `json:"low_count"`
+}
+
+// ScanFinding represents a single security finding in a scan.
+type ScanFinding struct {
+	ID          string  `json:"id"`
+	RuleID      string  `json:"rule_id"`
+	Severity    string  `json:"severity"`
+	Title       string  `json:"title"`
+	Description *string `json:"description,omitempty"`
+	Resource    *string `json:"resource,omitempty"`
+	FilePath    *string `json:"file_path,omitempty"`
+	LineNumber  *int    `json:"line_number,omitempty"`
+}
+
+// Scan represents a security scan result.
+type Scan struct {
+	ID             string        `json:"id"`
+	Status         string        `json:"status"`
+	Scanner        string        `json:"scanner"`
+	Passed         bool          `json:"passed"`
+	Findings       []ScanFinding `json:"findings,omitempty"`
+	ExecutionLog   *string       `json:"execution_log,omitempty"`
+	StartedAt      *string       `json:"started_at,omitempty"`
+	CompletedAt    *string       `json:"completed_at,omitempty"`
+	CreatedAt      string        `json:"created_at"`
+}
+
 // IdentityGroupMapping represents a single SAML/LDAP group → role mapping.
 type IdentityGroupMapping struct {
 	Group          string `json:"group"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -453,6 +453,32 @@ type UpdateTerraformMirrorRequest struct {
 	SyncIntervalHours *int     `json:"sync_interval_hours,omitempty"`
 }
 
+// TerraformMirrorVersionPlatform represents a platform entry for a mirrored Terraform version.
+type TerraformMirrorVersionPlatform struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+	URL  string `json:"url,omitempty"`
+}
+
+// TerraformMirrorVersion represents a single mirrored Terraform/OpenTofu version.
+type TerraformMirrorVersion struct {
+	ID        string                            `json:"id"`
+	Version   string                            `json:"version"`
+	Stable    bool                              `json:"stable"`
+	SyncedAt  *string                           `json:"synced_at,omitempty"`
+	Platforms []TerraformMirrorVersionPlatform  `json:"platforms,omitempty"`
+}
+
+// TerraformMirrorHistoryEntry represents one sync history record for a mirror.
+type TerraformMirrorHistoryEntry struct {
+	ID          string  `json:"id"`
+	StartedAt   string  `json:"started_at"`
+	CompletedAt *string `json:"completed_at,omitempty"`
+	Status      string  `json:"status"`
+	Message     *string `json:"message,omitempty"`
+	VersionsNew int     `json:"versions_new"`
+}
+
 // StorageConfig represents a storage backend configuration.
 type StorageConfig struct {
 	ID          string `json:"id"`

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,5 +1,21 @@
 package client
 
+// OIDCConfig represents the backend OIDC configuration (read-only).
+type OIDCConfig struct {
+	Issuer         string   `json:"issuer"`
+	ClientID       string   `json:"client_id"`
+	Scopes         []string `json:"scopes"`
+	GroupsClaim    string   `json:"groups_claim"`
+	UsernameClaim  string   `json:"username_claim"`
+}
+
+// OIDCGroupMapping represents a single OIDC group → role mapping entry.
+type OIDCGroupMapping struct {
+	OIDCGroup      string `json:"oidc_group"`
+	OrganizationID string `json:"organization_id"`
+	RoleTemplateID string `json:"role_template_id"`
+}
+
 // User represents a registry user.
 type User struct {
 	ID        string  `json:"id"`

--- a/internal/client/module_deprecations.go
+++ b/internal/client/module_deprecations.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeprecateModule sets module-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/deprecate.
+func (c *Client) DeprecateModule(ctx context.Context, namespace, name, system string, req DeprecateModuleRequest) (*Module, error) {
+	var mod Module
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/deprecate", namespace, name, system)
+	if err := c.Post(ctx, path, req, &mod); err != nil {
+		return nil, err
+	}
+	return &mod, nil
+}
+
+// UndeprecateModule removes module-level deprecation via DELETE /api/v1/modules/{ns}/{name}/{sys}/deprecate.
+func (c *Client) UndeprecateModule(ctx context.Context, namespace, name, system string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/modules/%s/%s/%s/deprecate", namespace, name, system))
+}
+
+// GetModuleVersion fetches a single module version for inspecting deprecation state.
+func (c *Client) GetModuleVersion(ctx context.Context, namespace, name, system, version string) (*ModuleVersion, error) {
+	var mv ModuleVersion
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/%s", namespace, name, system, version)
+	if err := c.Get(ctx, path, &mv); err != nil {
+		return nil, err
+	}
+	return &mv, nil
+}
+
+// DeprecateModuleVersion sets version-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/versions/{ver}/deprecate.
+func (c *Client) DeprecateModuleVersion(ctx context.Context, namespace, name, system, version string, req DeprecateModuleRequest) (*ModuleVersion, error) {
+	var mv ModuleVersion
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/deprecate", namespace, name, system, version)
+	if err := c.Post(ctx, path, req, &mv); err != nil {
+		return nil, err
+	}
+	return &mv, nil
+}
+
+// UndeprecateModuleVersion removes version-level deprecation via DELETE /api/v1/modules/{ns}/{name}/{sys}/versions/{ver}/deprecate.
+func (c *Client) UndeprecateModuleVersion(ctx context.Context, namespace, name, system, version string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/deprecate", namespace, name, system, version))
+}

--- a/internal/client/module_reanalyze.go
+++ b/internal/client/module_reanalyze.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReanalyzeModuleVersion triggers re-analysis of a module version via
+// POST /api/v1/modules/{ns}/{name}/{sys}/versions/{version}/reanalyze.
+func (c *Client) ReanalyzeModuleVersion(ctx context.Context, namespace, name, system, version string) error {
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/reanalyze", namespace, name, system, version)
+	resp, err := c.Do(ctx, "POST", path, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return parseResponseError(resp)
+}

--- a/internal/client/oidc.go
+++ b/internal/client/oidc.go
@@ -1,0 +1,30 @@
+package client
+
+import "context"
+
+// GetOIDCConfig fetches the current OIDC configuration via GET /api/v1/admin/oidc/config.
+func (c *Client) GetOIDCConfig(ctx context.Context) (*OIDCConfig, error) {
+	var cfg OIDCConfig
+	if err := c.Get(ctx, "/api/v1/admin/oidc/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// GetOIDCGroupMappings fetches the current OIDC group mappings via GET /api/v1/admin/oidc/group-mapping.
+func (c *Client) GetOIDCGroupMappings(ctx context.Context) ([]OIDCGroupMapping, error) {
+	var mappings []OIDCGroupMapping
+	if err := c.Get(ctx, "/api/v1/admin/oidc/group-mapping", &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// SetOIDCGroupMappings replaces the entire OIDC group mapping table via PUT /api/v1/admin/oidc/group-mapping.
+func (c *Client) SetOIDCGroupMappings(ctx context.Context, mappings []OIDCGroupMapping) ([]OIDCGroupMapping, error) {
+	var result []OIDCGroupMapping
+	if err := c.Put(ctx, "/api/v1/admin/oidc/group-mapping", mappings, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/client/policy_engine.go
+++ b/internal/client/policy_engine.go
@@ -1,0 +1,21 @@
+package client
+
+import "context"
+
+// GetPolicyEngineConfig fetches the rego bundle config via GET /api/v1/admin/policy/config.
+func (c *Client) GetPolicyEngineConfig(ctx context.Context) (*PolicyEngineConfig, error) {
+	var cfg PolicyEngineConfig
+	if err := c.Get(ctx, "/api/v1/admin/policy/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// EvaluatePolicy evaluates input against the rego bundle via POST /api/v1/admin/policy/evaluate.
+func (c *Client) EvaluatePolicy(ctx context.Context, req PolicyEvaluateRequest) (*PolicyEvaluateResult, error) {
+	var result PolicyEvaluateResult
+	if err := c.Post(ctx, "/api/v1/admin/policy/evaluate", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/client/provider_deprecations.go
+++ b/internal/client/provider_deprecations.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetProviderVersion fetches a single provider version for inspecting deprecation state.
+func (c *Client) GetProviderVersion(ctx context.Context, namespace, providerType, version string) (*ProviderVersion, error) {
+	var pv ProviderVersion
+	path := fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s", namespace, providerType, version)
+	if err := c.Get(ctx, path, &pv); err != nil {
+		return nil, err
+	}
+	return &pv, nil
+}
+
+// DeprecateProviderVersion sets version-level deprecation via POST /api/v1/providers/{ns}/{type}/versions/{ver}/deprecate.
+func (c *Client) DeprecateProviderVersion(ctx context.Context, namespace, providerType, version string, req DeprecateProviderVersionRequest) (*ProviderVersion, error) {
+	var pv ProviderVersion
+	path := fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s/deprecate", namespace, providerType, version)
+	if err := c.Post(ctx, path, req, &pv); err != nil {
+		return nil, err
+	}
+	return &pv, nil
+}
+
+// UndeprecateProviderVersion removes version-level deprecation via DELETE /api/v1/providers/{ns}/{type}/versions/{ver}/deprecate.
+func (c *Client) UndeprecateProviderVersion(ctx context.Context, namespace, providerType, version string) error {
+	return c.Delete(ctx, fmt.Sprintf("/api/v1/providers/%s/%s/versions/%s/deprecate", namespace, providerType, version))
+}

--- a/internal/client/scanning.go
+++ b/internal/client/scanning.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetScanningConfig fetches the scanner configuration via GET /api/v1/admin/scanning/config.
+func (c *Client) GetScanningConfig(ctx context.Context) (*ScanningConfig, error) {
+	var cfg ScanningConfig
+	if err := c.Get(ctx, "/api/v1/admin/scanning/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// GetScanningStats fetches aggregate scan statistics via GET /api/v1/admin/scanning/stats.
+func (c *Client) GetScanningStats(ctx context.Context) (*ScanningStats, error) {
+	var stats ScanningStats
+	if err := c.Get(ctx, "/api/v1/admin/scanning/stats", &stats); err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+// GetScan fetches a scan by UUID via GET /api/v1/admin/scanning/scans/{id}.
+func (c *Client) GetScan(ctx context.Context, id string) (*Scan, error) {
+	var s Scan
+	if err := c.Get(ctx, "/api/v1/admin/scanning/scans/"+id, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// GetModuleScan fetches the most recent scan for a module version.
+func (c *Client) GetModuleScan(ctx context.Context, namespace, name, system, version string) (*Scan, error) {
+	var s Scan
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/versions/%s/scan", namespace, name, system, version)
+	if err := c.Get(ctx, path, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/client/storage_migrations.go
+++ b/internal/client/storage_migrations.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+// CreateStorageMigration starts a new migration via POST /api/v1/admin/storage/migrations.
+func (c *Client) CreateStorageMigration(ctx context.Context, req CreateStorageMigrationRequest) (*StorageMigration, error) {
+	var m StorageMigration
+	if err := c.Post(ctx, "/api/v1/admin/storage/migrations", req, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// GetStorageMigration fetches migration status via GET /api/v1/admin/storage/migrations/{id}.
+func (c *Client) GetStorageMigration(ctx context.Context, id string) (*StorageMigration, error) {
+	var m StorageMigration
+	if err := c.Get(ctx, "/api/v1/admin/storage/migrations/"+id, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// CancelStorageMigration cancels an in-flight migration via POST /api/v1/admin/storage/migrations/{id}/cancel.
+func (c *Client) CancelStorageMigration(ctx context.Context, id string) (*StorageMigration, error) {
+	var m StorageMigration
+	if err := c.Post(ctx, fmt.Sprintf("/api/v1/admin/storage/migrations/%s/cancel", id), nil, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}

--- a/internal/client/terraform_mirror_versions.go
+++ b/internal/client/terraform_mirror_versions.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListTerraformMirrorVersions returns all versions for a given mirror config.
+func (c *Client) ListTerraformMirrorVersions(ctx context.Context, mirrorID string) ([]TerraformMirrorVersion, error) {
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/versions", mirrorID)
+	items, err := FetchAllPages(ctx, c, path, "versions")
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]TerraformMirrorVersion, 0, len(items))
+	for _, raw := range items {
+		var v TerraformMirrorVersion
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("unmarshaling mirror version: %w", err)
+		}
+		versions = append(versions, v)
+	}
+	return versions, nil
+}
+
+// GetTerraformMirrorVersion returns a single version (including platforms).
+func (c *Client) GetTerraformMirrorVersion(ctx context.Context, mirrorID, version string) (*TerraformMirrorVersion, error) {
+	var v TerraformMirrorVersion
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/versions/%s", mirrorID, version)
+	if err := c.Get(ctx, path, &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// ListTerraformMirrorHistory returns the sync history for a mirror.
+func (c *Client) ListTerraformMirrorHistory(ctx context.Context, mirrorID string) ([]TerraformMirrorHistoryEntry, error) {
+	path := fmt.Sprintf("/api/v1/admin/terraform-mirrors/%s/history", mirrorID)
+	items, err := FetchAllPages(ctx, c, path, "history")
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]TerraformMirrorHistoryEntry, 0, len(items))
+	for _, raw := range items {
+		var e TerraformMirrorHistoryEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("unmarshaling history entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}

--- a/internal/client/version.go
+++ b/internal/client/version.go
@@ -1,0 +1,22 @@
+package client
+
+import "context"
+
+// BackendVersion holds the response from GET /version.
+type BackendVersion struct {
+	Version         string   `json:"version"`
+	BuildDate       string   `json:"build_date"`
+	APIVersion      string   `json:"api_version"`
+	DefaultLanguage string   `json:"default_language"`
+	Protocols       []string `json:"protocols"`
+	Capabilities    []string `json:"capabilities"`
+}
+
+// GetVersion calls GET /version and returns the backend version info.
+func (c *Client) GetVersion(ctx context.Context) (*BackendVersion, error) {
+	var v BackendVersion
+	if err := c.Get(ctx, "/version", &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}

--- a/internal/client/version_test.go
+++ b/internal/client/version_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBackendVersion_Decode(t *testing.T) {
+	body := []byte(`{
+		"version": "1.0.0",
+		"build_date": "2026-04-01T00:00:00Z",
+		"api_version": "1",
+		"default_language": "en",
+		"protocols": ["terraform.io/v1"],
+		"capabilities": ["modules", "providers"]
+	}`)
+
+	var v BackendVersion
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if v.Version != "1.0.0" {
+		t.Errorf("Version = %q, want 1.0.0", v.Version)
+	}
+	if v.APIVersion != "1" {
+		t.Errorf("APIVersion = %q, want 1", v.APIVersion)
+	}
+	if len(v.Protocols) != 1 || v.Protocols[0] != "terraform.io/v1" {
+		t.Errorf("Protocols = %v, want [terraform.io/v1]", v.Protocols)
+	}
+}

--- a/internal/provider/datasource_advisories.go
+++ b/internal/provider/datasource_advisories.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &AdvisoriesDataSource{}
+
+type AdvisoriesDataSource struct {
+	client *client.Client
+}
+
+type AdvisoryItemModel struct {
+	ID          types.String `tfsdk:"id"`
+	ExternalID  types.String `tfsdk:"external_id"`
+	Title       types.String `tfsdk:"title"`
+	Description types.String `tfsdk:"description"`
+	Severity    types.String `tfsdk:"severity"`
+	URL         types.String `tfsdk:"url"`
+	PublishedAt types.String `tfsdk:"published_at"`
+	ResolvedAt  types.String `tfsdk:"resolved_at"`
+	Active      types.Bool   `tfsdk:"active"`
+}
+
+type AdvisoriesDataSourceModel struct {
+	ActiveOnly types.Bool          `tfsdk:"active_only"`
+	Severities types.List          `tfsdk:"severities"`
+	Advisories []AdvisoryItemModel `tfsdk:"advisories"`
+}
+
+func NewAdvisoriesDataSource() datasource.DataSource {
+	return &AdvisoriesDataSource{}
+}
+
+func (d *AdvisoriesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_advisories"
+}
+
+func (d *AdvisoriesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists CVE security advisories from the registry. Use active_only = true to restrict to currently active advisories.",
+		Attributes: map[string]schema.Attribute{
+			"active_only": schema.BoolAttribute{
+				Description: "If true, only returns currently active advisories. Defaults to false (returns all).",
+				Optional:    true,
+			},
+			"severities": schema.ListAttribute{
+				Description: "Optional list of severity values to filter by (e.g. ['high', 'critical']).",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"advisories": schema.ListNestedAttribute{
+				Description: "List of matching advisories.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id":          schema.StringAttribute{Description: "Internal UUID.", Computed: true},
+						"external_id": schema.StringAttribute{Description: "CVE identifier (e.g. CVE-2024-12345).", Computed: true},
+						"title":       schema.StringAttribute{Description: "Advisory title.", Computed: true},
+						"description": schema.StringAttribute{Description: "Advisory description.", Computed: true},
+						"severity":    schema.StringAttribute{Description: "Severity level.", Computed: true},
+						"url":         schema.StringAttribute{Description: "Reference URL.", Computed: true},
+						"published_at": schema.StringAttribute{Description: "ISO 8601 publish timestamp.", Computed: true},
+						"resolved_at":  schema.StringAttribute{Description: "ISO 8601 resolution timestamp (empty if unresolved).", Computed: true},
+						"active":      schema.BoolAttribute{Description: "Whether the advisory is currently active.", Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *AdvisoriesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *AdvisoriesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state AdvisoriesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	activeOnly := !state.ActiveOnly.IsNull() && !state.ActiveOnly.IsUnknown() && state.ActiveOnly.ValueBool()
+
+	var severities []string
+	if !state.Severities.IsNull() && !state.Severities.IsUnknown() {
+		resp.Diagnostics.Append(state.Severities.ElementsAs(ctx, &severities, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	advisories, err := d.client.ListAdvisories(ctx, activeOnly, severities)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Advisories", err.Error())
+		return
+	}
+
+	items := make([]AdvisoryItemModel, 0, len(advisories))
+	for _, a := range advisories {
+		item := AdvisoryItemModel{
+			ID:         types.StringValue(a.ID),
+			ExternalID: types.StringValue(a.ExternalID),
+			Title:      types.StringValue(a.Title),
+			Severity:   types.StringValue(a.Severity),
+			Active:     types.BoolValue(a.Active),
+		}
+		optStr := func(s *string) types.String {
+			if s != nil {
+				return types.StringValue(*s)
+			}
+			return types.StringValue("")
+		}
+		item.Description = optStr(a.Description)
+		item.URL = optStr(a.URL)
+		if a.PublishedAt != nil {
+			item.PublishedAt = types.StringValue(normalizeTimestamp(*a.PublishedAt))
+		} else {
+			item.PublishedAt = types.StringValue("")
+		}
+		if a.ResolvedAt != nil {
+			item.ResolvedAt = types.StringValue(normalizeTimestamp(*a.ResolvedAt))
+		} else {
+			item.ResolvedAt = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.Advisories = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_audit_log.go
+++ b/internal/provider/datasource_audit_log.go
@@ -1,0 +1,146 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &AuditLogDataSource{}
+
+type AuditLogDataSource struct {
+	client *client.Client
+}
+
+type AuditLogDataSourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	UserID         types.String `tfsdk:"user_id"`
+	UserEmail      types.String `tfsdk:"user_email"`
+	UserName       types.String `tfsdk:"user_name"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Action         types.String `tfsdk:"action"`
+	ResourceType   types.String `tfsdk:"resource_type"`
+	ResourceID     types.String `tfsdk:"resource_id"`
+	MetadataJSON   types.String `tfsdk:"metadata_json"`
+	IPAddress      types.String `tfsdk:"ip_address"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+}
+
+func NewAuditLogDataSource() datasource.DataSource {
+	return &AuditLogDataSource{}
+}
+
+func (d *AuditLogDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_audit_log"
+}
+
+func (d *AuditLogDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches a single audit log entry by UUID.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "UUID of the audit log entry to fetch.",
+				Required:    true,
+			},
+			"user_id": schema.StringAttribute{
+				Description: "UUID of the user who performed the action.",
+				Computed:    true,
+			},
+			"user_email": schema.StringAttribute{
+				Description: "Email of the user who performed the action.",
+				Computed:    true,
+			},
+			"user_name": schema.StringAttribute{
+				Description: "Display name of the user.",
+				Computed:    true,
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization context.",
+				Computed:    true,
+			},
+			"action": schema.StringAttribute{
+				Description: "Action performed (e.g. 'create', 'update', 'delete').",
+				Computed:    true,
+			},
+			"resource_type": schema.StringAttribute{
+				Description: "Type of resource affected.",
+				Computed:    true,
+			},
+			"resource_id": schema.StringAttribute{
+				Description: "UUID of the affected resource.",
+				Computed:    true,
+			},
+			"metadata_json": schema.StringAttribute{
+				Description: "Additional metadata serialised as JSON.",
+				Computed:    true,
+			},
+			"ip_address": schema.StringAttribute{
+				Description: "IP address of the requester.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp of the event.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *AuditLogDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *AuditLogDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state AuditLogDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	l, err := d.client.GetAuditLog(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Audit Log", err.Error())
+		return
+	}
+
+	state.Action = types.StringValue(l.Action)
+	state.CreatedAt = types.StringValue(normalizeTimestamp(l.CreatedAt))
+
+	setOptStr := func(dest *types.String, src *string) {
+		if src != nil {
+			*dest = types.StringValue(*src)
+		} else {
+			*dest = types.StringValue("")
+		}
+	}
+	setOptStr(&state.UserID, l.UserID)
+	setOptStr(&state.UserEmail, l.UserEmail)
+	setOptStr(&state.UserName, l.UserName)
+	setOptStr(&state.OrganizationID, l.OrganizationID)
+	setOptStr(&state.ResourceType, l.ResourceType)
+	setOptStr(&state.ResourceID, l.ResourceID)
+	setOptStr(&state.IPAddress, l.IPAddress)
+
+	metaJSON := "{}"
+	if l.Metadata != nil {
+		if b, err := json.Marshal(l.Metadata); err == nil {
+			metaJSON = string(b)
+		}
+	}
+	state.MetadataJSON = types.StringValue(metaJSON)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_identity_group_mappings.go
+++ b/internal/provider/datasource_identity_group_mappings.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &IdentityGroupMappingsDataSource{}
+
+type IdentityGroupMappingsDataSource struct {
+	client *client.Client
+}
+
+type IdentityGroupMappingItemModel struct {
+	Group          types.String `tfsdk:"group"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	RoleTemplateID types.String `tfsdk:"role_template_id"`
+}
+
+type IdentityGroupMappingsDataSourceModel struct {
+	Mappings []IdentityGroupMappingItemModel `tfsdk:"mappings"`
+}
+
+func NewIdentityGroupMappingsDataSource() datasource.DataSource {
+	return &IdentityGroupMappingsDataSource{}
+}
+
+func (d *IdentityGroupMappingsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_identity_group_mappings"
+}
+
+func (d *IdentityGroupMappingsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the SAML/LDAP group → organization role mappings from the backend runtime config (read-only).",
+		Attributes: map[string]schema.Attribute{
+			"mappings": schema.ListNestedAttribute{
+				Description: "List of identity group → role mappings.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"group": schema.StringAttribute{
+							Description: "SAML/LDAP group identifier.",
+							Computed:    true,
+						},
+						"organization_id": schema.StringAttribute{
+							Description: "UUID of the target organization.",
+							Computed:    true,
+						},
+						"role_template_id": schema.StringAttribute{
+							Description: "UUID of the role template assigned to members of this group.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *IdentityGroupMappingsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *IdentityGroupMappingsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	mappings, err := d.client.GetIdentityGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Identity Group Mappings", err.Error())
+		return
+	}
+
+	items := make([]IdentityGroupMappingItemModel, 0, len(mappings))
+	for _, m := range mappings {
+		items = append(items, IdentityGroupMappingItemModel{
+			Group:          types.StringValue(m.Group),
+			OrganizationID: types.StringValue(m.OrganizationID),
+			RoleTemplateID: types.StringValue(m.RoleTemplateID),
+		})
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, IdentityGroupMappingsDataSourceModel{Mappings: items})...)
+}

--- a/internal/provider/datasource_mtls_config.go
+++ b/internal/provider/datasource_mtls_config.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &MTLSConfigDataSource{}
+
+type MTLSConfigDataSource struct {
+	client *client.Client
+}
+
+type MTLSConfigDataSourceModel struct {
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	ClientCACN types.String `tfsdk:"client_ca_cn"`
+	ServerCert types.String `tfsdk:"server_cert_subject"`
+}
+
+func NewMTLSConfigDataSource() datasource.DataSource {
+	return &MTLSConfigDataSource{}
+}
+
+func (d *MTLSConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mtls_config"
+}
+
+func (d *MTLSConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend mTLS server certificate and CA configuration (read-only, sourced from backend startup config).",
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: "Whether mTLS is enabled on the backend.",
+				Computed:    true,
+			},
+			"client_ca_cn": schema.StringAttribute{
+				Description: "Common name of the client CA certificate.",
+				Computed:    true,
+			},
+			"server_cert_subject": schema.StringAttribute{
+				Description: "Subject of the server TLS certificate.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *MTLSConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *MTLSConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetMTLSConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading mTLS Config", err.Error())
+		return
+	}
+
+	model := MTLSConfigDataSourceModel{
+		Enabled: types.BoolValue(cfg.Enabled),
+	}
+	if cfg.ClientCACN != nil {
+		model.ClientCACN = types.StringValue(*cfg.ClientCACN)
+	} else {
+		model.ClientCACN = types.StringValue("")
+	}
+	if cfg.ServerCert != nil {
+		model.ServerCert = types.StringValue(*cfg.ServerCert)
+	} else {
+		model.ServerCert = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_oidc_config.go
+++ b/internal/provider/datasource_oidc_config.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &OIDCConfigDataSource{}
+
+type OIDCConfigDataSource struct {
+	client *client.Client
+}
+
+type OIDCConfigDataSourceModel struct {
+	Issuer        types.String `tfsdk:"issuer"`
+	ClientID      types.String `tfsdk:"client_id"`
+	Scopes        types.List   `tfsdk:"scopes"`
+	GroupsClaim   types.String `tfsdk:"groups_claim"`
+	UsernameClaim types.String `tfsdk:"username_claim"`
+}
+
+func NewOIDCConfigDataSource() datasource.DataSource {
+	return &OIDCConfigDataSource{}
+}
+
+func (d *OIDCConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_config"
+}
+
+func (d *OIDCConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend OIDC configuration (read-only). The client secret is never exposed.",
+		Attributes: map[string]schema.Attribute{
+			"issuer": schema.StringAttribute{
+				Description: "OIDC issuer URL.",
+				Computed:    true,
+			},
+			"client_id": schema.StringAttribute{
+				Description: "OIDC client ID.",
+				Computed:    true,
+			},
+			"scopes": schema.ListAttribute{
+				Description: "Requested OIDC scopes.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"groups_claim": schema.StringAttribute{
+				Description: "JWT claim used to extract group membership.",
+				Computed:    true,
+			},
+			"username_claim": schema.StringAttribute{
+				Description: "JWT claim used as the username.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *OIDCConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *OIDCConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetOIDCConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Config", err.Error())
+		return
+	}
+
+	scopes, diags := types.ListValueFrom(ctx, types.StringType, cfg.Scopes)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	model := OIDCConfigDataSourceModel{
+		Issuer:        types.StringValue(cfg.Issuer),
+		ClientID:      types.StringValue(cfg.ClientID),
+		Scopes:        scopes,
+		GroupsClaim:   types.StringValue(cfg.GroupsClaim),
+		UsernameClaim: types.StringValue(cfg.UsernameClaim),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_policy_engine_config.go
+++ b/internal/provider/datasource_policy_engine_config.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &PolicyEngineConfigDataSource{}
+
+type PolicyEngineConfigDataSource struct {
+	client *client.Client
+}
+
+type PolicyEngineConfigDataSourceModel struct {
+	BundleURL    types.String `tfsdk:"bundle_url"`
+	BundleETag   types.String `tfsdk:"bundle_etag"`
+	LastLoadedAt types.String `tfsdk:"last_loaded_at"`
+	Status       types.String `tfsdk:"status"`
+}
+
+func NewPolicyEngineConfigDataSource() datasource.DataSource {
+	return &PolicyEngineConfigDataSource{}
+}
+
+func (d *PolicyEngineConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_engine_config"
+}
+
+func (d *PolicyEngineConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the rego policy engine bundle configuration.",
+		Attributes: map[string]schema.Attribute{
+			"bundle_url": schema.StringAttribute{
+				Description: "URL from which the rego bundle is loaded.",
+				Computed:    true,
+			},
+			"bundle_etag": schema.StringAttribute{
+				Description: "ETag of the currently loaded bundle.",
+				Computed:    true,
+			},
+			"last_loaded_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the bundle was last loaded.",
+				Computed:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Bundle load status ('ok', 'error', etc.).",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *PolicyEngineConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *PolicyEngineConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetPolicyEngineConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Policy Engine Config", err.Error())
+		return
+	}
+
+	model := PolicyEngineConfigDataSourceModel{
+		BundleURL: types.StringValue(cfg.BundleURL),
+		Status:    types.StringValue(cfg.Status),
+	}
+	if cfg.BundleETag != nil {
+		model.BundleETag = types.StringValue(*cfg.BundleETag)
+	} else {
+		model.BundleETag = types.StringValue("")
+	}
+	if cfg.LastLoadedAt != nil {
+		model.LastLoadedAt = types.StringValue(normalizeTimestamp(*cfg.LastLoadedAt))
+	} else {
+		model.LastLoadedAt = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_policy_evaluation.go
+++ b/internal/provider/datasource_policy_evaluation.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &PolicyEvaluationDataSource{}
+
+type PolicyEvaluationDataSource struct {
+	client *client.Client
+}
+
+type PolicyEvaluationDataSourceModel struct {
+	InputJSON  types.String `tfsdk:"input_json"`
+	Query      types.String `tfsdk:"query"`
+	Allowed    types.Bool   `tfsdk:"allowed"`
+	Reason     types.String `tfsdk:"reason"`
+	ResultJSON types.String `tfsdk:"result_json"`
+}
+
+func NewPolicyEvaluationDataSource() datasource.DataSource {
+	return &PolicyEvaluationDataSource{}
+}
+
+func (d *PolicyEvaluationDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy_evaluation"
+}
+
+func (d *PolicyEvaluationDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Evaluates input against the rego policy bundle at plan time. Useful for policy-gating resource creation.",
+		Attributes: map[string]schema.Attribute{
+			"input_json": schema.StringAttribute{
+				Description: "JSON-encoded input document to evaluate against the policy bundle.",
+				Required:    true,
+			},
+			"query": schema.StringAttribute{
+				Description: "Optional rego query path (e.g. 'data.authz.allow'). Defaults to the bundle entry point if omitted.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"allowed": schema.BoolAttribute{
+				Description: "Whether the policy evaluation returned an allow decision.",
+				Computed:    true,
+			},
+			"reason": schema.StringAttribute{
+				Description: "Human-readable reason returned by the policy (if provided).",
+				Computed:    true,
+			},
+			"result_json": schema.StringAttribute{
+				Description: "Full policy result serialised as JSON.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *PolicyEvaluationDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *PolicyEvaluationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state PolicyEvaluationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var input map[string]interface{}
+	if err := json.Unmarshal([]byte(state.InputJSON.ValueString()), &input); err != nil {
+		resp.Diagnostics.AddError("Invalid input_json", "input_json must be a valid JSON object: "+err.Error())
+		return
+	}
+
+	evalReq := client.PolicyEvaluateRequest{Input: input}
+	if !state.Query.IsNull() && !state.Query.IsUnknown() {
+		evalReq.Query = state.Query.ValueString()
+	}
+
+	result, err := d.client.EvaluatePolicy(ctx, evalReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Evaluating Policy", err.Error())
+		return
+	}
+
+	state.Allowed = types.BoolValue(result.Allowed)
+	if result.Reason != nil {
+		state.Reason = types.StringValue(*result.Reason)
+	} else {
+		state.Reason = types.StringValue("")
+	}
+	if state.Query.IsNull() || state.Query.IsUnknown() {
+		state.Query = types.StringValue("")
+	}
+
+	resultJSON := "{}"
+	if result.Result != nil {
+		if b, err := json.Marshal(result.Result); err == nil {
+			resultJSON = string(b)
+		}
+	}
+	state.ResultJSON = types.StringValue(resultJSON)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_scan.go
+++ b/internal/provider/datasource_scan.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanDataSource{}
+
+type ScanDataSource struct {
+	client *client.Client
+}
+
+type ScanDataSourceModel struct {
+	ScanDataModel
+}
+
+func NewScanDataSource() datasource.DataSource {
+	return &ScanDataSource{}
+}
+
+func (d *ScanDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scan"
+}
+
+func (d *ScanDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches a single security scan by UUID.",
+		Attributes:  scanResultSchema(),
+	}
+}
+
+func (d *ScanDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ScanDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	s, err := d.client.GetScan(ctx, state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scan", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, ScanDataSourceModel{scanToModel(s)})...)
+}
+
+// scanResultSchema returns the shared schema for scan result attributes.
+func scanResultSchema() map[string]schema.Attribute {
+	findingAttrs := schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"id":          schema.StringAttribute{Description: "UUID of the finding.", Computed: true},
+			"rule_id":     schema.StringAttribute{Description: "Rule identifier.", Computed: true},
+			"severity":    schema.StringAttribute{Description: "Finding severity.", Computed: true},
+			"title":       schema.StringAttribute{Description: "Finding title.", Computed: true},
+			"description": schema.StringAttribute{Description: "Finding description.", Computed: true},
+			"resource":    schema.StringAttribute{Description: "Affected resource name.", Computed: true},
+			"file_path":   schema.StringAttribute{Description: "Source file path.", Computed: true},
+			"line_number": schema.Int64Attribute{Description: "Line number in the source file.", Computed: true},
+		},
+	}
+	return map[string]schema.Attribute{
+		"id":            schema.StringAttribute{Description: "UUID of the scan (required for registry_scan; computed for registry_module_scan).", Optional: true, Computed: true},
+		"status":        schema.StringAttribute{Description: "Scan status.", Computed: true},
+		"scanner":       schema.StringAttribute{Description: "Scanner tool name.", Computed: true},
+		"passed":        schema.BoolAttribute{Description: "Whether the scan passed.", Computed: true},
+		"execution_log": schema.StringAttribute{Description: "Raw scanner output.", Computed: true},
+		"started_at":    schema.StringAttribute{Description: "ISO 8601 start timestamp.", Computed: true},
+		"completed_at":  schema.StringAttribute{Description: "ISO 8601 completion timestamp.", Computed: true},
+		"created_at":    schema.StringAttribute{Description: "ISO 8601 creation timestamp.", Computed: true},
+		"findings": schema.ListNestedAttribute{
+			Description:  "Security findings from the scan.",
+			Computed:     true,
+			NestedObject: findingAttrs,
+		},
+	}
+}
+
+// moduleScanSchema extends scanResultSchema with module-addressing attributes.
+func moduleScanSchema() map[string]schema.Attribute {
+	attrs := scanResultSchema()
+	attrs["namespace"] = schema.StringAttribute{Description: "Module namespace.", Required: true}
+	attrs["name"] = schema.StringAttribute{Description: "Module name.", Required: true}
+	attrs["system"] = schema.StringAttribute{Description: "Module system.", Required: true}
+	attrs["version"] = schema.StringAttribute{Description: "Module version.", Required: true}
+	// id is computed only for module scan (not required)
+	delete(attrs, "id")
+	attrs["id"] = schema.StringAttribute{Description: "UUID of the scan.", Computed: true}
+	return attrs
+}
+
+// ModuleScanDataSource fetches the most recent scan for a module version.
+type ModuleScanDataSource struct {
+	client *client.Client
+}
+
+var _ datasource.DataSource = &ModuleScanDataSource{}
+
+type ModuleScanDataSourceModel struct {
+	Namespace types.String `tfsdk:"namespace"`
+	Name      types.String `tfsdk:"name"`
+	System    types.String `tfsdk:"system"`
+	Version   types.String `tfsdk:"version"`
+	ScanDataModel
+}
+
+func NewModuleScanDataSource() datasource.DataSource {
+	return &ModuleScanDataSource{}
+}
+
+func (d *ModuleScanDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_scan"
+}
+
+func (d *ModuleScanDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches the most recent security scan result for a specific module version.",
+		Attributes:  moduleScanSchema(),
+	}
+}
+
+func (d *ModuleScanDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ModuleScanDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ModuleScanDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	s, err := d.client.GetModuleScan(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Module Scan", err.Error())
+		return
+	}
+
+	scanModel := scanToModel(s)
+	result := ModuleScanDataSourceModel{
+		Namespace:     state.Namespace,
+		Name:          state.Name,
+		System:        state.System,
+		Version:       state.Version,
+		ScanDataModel: scanModel,
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+}

--- a/internal/provider/datasource_scanning_config.go
+++ b/internal/provider/datasource_scanning_config.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanningConfigDataSource{}
+
+type ScanningConfigDataSource struct {
+	client *client.Client
+}
+
+type ScanningConfigDataSourceModel struct {
+	Enabled         types.Bool   `tfsdk:"enabled"`
+	BinaryPath      types.String `tfsdk:"binary_path"`
+	DetectedVersion types.String `tfsdk:"detected_version"`
+	EnabledTools    types.List   `tfsdk:"enabled_tools"`
+}
+
+func NewScanningConfigDataSource() datasource.DataSource {
+	return &ScanningConfigDataSource{}
+}
+
+func (d *ScanningConfigDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scanning_config"
+}
+
+func (d *ScanningConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads the backend security scanner configuration.",
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.BoolAttribute{
+				Description: "Whether security scanning is enabled.",
+				Computed:    true,
+			},
+			"binary_path": schema.StringAttribute{
+				Description: "Path to the scanner binary.",
+				Computed:    true,
+			},
+			"detected_version": schema.StringAttribute{
+				Description: "Detected scanner version string.",
+				Computed:    true,
+			},
+			"enabled_tools": schema.ListAttribute{
+				Description: "List of enabled scanning tools.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *ScanningConfigDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanningConfigDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	cfg, err := d.client.GetScanningConfig(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scanning Config", err.Error())
+		return
+	}
+
+	tools, diags := types.ListValueFrom(ctx, types.StringType, cfg.EnabledTools)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	model := ScanningConfigDataSourceModel{
+		Enabled:      types.BoolValue(cfg.Enabled),
+		EnabledTools: tools,
+	}
+	if cfg.BinaryPath != nil {
+		model.BinaryPath = types.StringValue(*cfg.BinaryPath)
+	} else {
+		model.BinaryPath = types.StringValue("")
+	}
+	if cfg.DetectedVersion != nil {
+		model.DetectedVersion = types.StringValue(*cfg.DetectedVersion)
+	} else {
+		model.DetectedVersion = types.StringValue("")
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}

--- a/internal/provider/datasource_scanning_stats.go
+++ b/internal/provider/datasource_scanning_stats.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &ScanningStatsDataSource{}
+
+type ScanningStatsDataSource struct {
+	client *client.Client
+}
+
+type ScanningStatsDataSourceModel struct {
+	TotalScans    types.Int64 `tfsdk:"total_scans"`
+	PassedScans   types.Int64 `tfsdk:"passed_scans"`
+	FailedScans   types.Int64 `tfsdk:"failed_scans"`
+	PendingScans  types.Int64 `tfsdk:"pending_scans"`
+	TotalFindings types.Int64 `tfsdk:"total_findings"`
+	CriticalCount types.Int64 `tfsdk:"critical_count"`
+	HighCount     types.Int64 `tfsdk:"high_count"`
+	MediumCount   types.Int64 `tfsdk:"medium_count"`
+	LowCount      types.Int64 `tfsdk:"low_count"`
+}
+
+func NewScanningStatsDataSource() datasource.DataSource {
+	return &ScanningStatsDataSource{}
+}
+
+func (d *ScanningStatsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_scanning_stats"
+}
+
+func (d *ScanningStatsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads aggregate security scan statistics.",
+		Attributes: map[string]schema.Attribute{
+			"total_scans":    schema.Int64Attribute{Description: "Total number of scans.", Computed: true},
+			"passed_scans":   schema.Int64Attribute{Description: "Number of scans that passed.", Computed: true},
+			"failed_scans":   schema.Int64Attribute{Description: "Number of scans that failed.", Computed: true},
+			"pending_scans":  schema.Int64Attribute{Description: "Number of scans pending or running.", Computed: true},
+			"total_findings": schema.Int64Attribute{Description: "Total findings across all scans.", Computed: true},
+			"critical_count": schema.Int64Attribute{Description: "Critical severity findings.", Computed: true},
+			"high_count":     schema.Int64Attribute{Description: "High severity findings.", Computed: true},
+			"medium_count":   schema.Int64Attribute{Description: "Medium severity findings.", Computed: true},
+			"low_count":      schema.Int64Attribute{Description: "Low severity findings.", Computed: true},
+		},
+	}
+}
+
+func (d *ScanningStatsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *ScanningStatsDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	stats, err := d.client.GetScanningStats(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Scanning Stats", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, ScanningStatsDataSourceModel{
+		TotalScans:    types.Int64Value(int64(stats.TotalScans)),
+		PassedScans:   types.Int64Value(int64(stats.PassedScans)),
+		FailedScans:   types.Int64Value(int64(stats.FailedScans)),
+		PendingScans:  types.Int64Value(int64(stats.PendingScans)),
+		TotalFindings: types.Int64Value(int64(stats.TotalFindings)),
+		CriticalCount: types.Int64Value(int64(stats.CriticalCount)),
+		HighCount:     types.Int64Value(int64(stats.HighCount)),
+		MediumCount:   types.Int64Value(int64(stats.MediumCount)),
+		LowCount:      types.Int64Value(int64(stats.LowCount)),
+	})...)
+}

--- a/internal/provider/datasource_terraform_mirror_history.go
+++ b/internal/provider/datasource_terraform_mirror_history.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorHistoryDataSource{}
+
+type TerraformMirrorHistoryDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorHistoryEntryModel struct {
+	ID          types.String `tfsdk:"id"`
+	StartedAt   types.String `tfsdk:"started_at"`
+	CompletedAt types.String `tfsdk:"completed_at"`
+	Status      types.String `tfsdk:"status"`
+	Message     types.String `tfsdk:"message"`
+	VersionsNew types.Int64  `tfsdk:"versions_new"`
+}
+
+type TerraformMirrorHistoryDataSourceModel struct {
+	MirrorID types.String                       `tfsdk:"mirror_id"`
+	History  []TerraformMirrorHistoryEntryModel `tfsdk:"history"`
+}
+
+func NewTerraformMirrorHistoryDataSource() datasource.DataSource {
+	return &TerraformMirrorHistoryDataSource{}
+}
+
+func (d *TerraformMirrorHistoryDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_history"
+}
+
+func (d *TerraformMirrorHistoryDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists the sync history entries for a Terraform/OpenTofu mirror configuration.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"history": schema.ListNestedAttribute{
+				Description: "Sync history entries, newest first.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "UUID of the history record.",
+							Computed:    true,
+						},
+						"started_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when the sync started.",
+							Computed:    true,
+						},
+						"completed_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when the sync completed (empty if still running).",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Sync status: 'pending', 'running', 'succeeded', or 'failed'.",
+							Computed:    true,
+						},
+						"message": schema.StringAttribute{
+							Description: "Optional status message or error detail.",
+							Computed:    true,
+						},
+						"versions_new": schema.Int64Attribute{
+							Description: "Number of new versions discovered in this sync.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorHistoryDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorHistoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorHistoryDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	entries, err := d.client.ListTerraformMirrorHistory(ctx, state.MirrorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Terraform Mirror History", err.Error())
+		return
+	}
+
+	items := make([]TerraformMirrorHistoryEntryModel, 0, len(entries))
+	for _, e := range entries {
+		item := TerraformMirrorHistoryEntryModel{
+			ID:          types.StringValue(e.ID),
+			StartedAt:   types.StringValue(normalizeTimestamp(e.StartedAt)),
+			Status:      types.StringValue(e.Status),
+			VersionsNew: types.Int64Value(int64(e.VersionsNew)),
+		}
+		if e.CompletedAt != nil {
+			item.CompletedAt = types.StringValue(normalizeTimestamp(*e.CompletedAt))
+		} else {
+			item.CompletedAt = types.StringValue("")
+		}
+		if e.Message != nil {
+			item.Message = types.StringValue(*e.Message)
+		} else {
+			item.Message = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.History = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_terraform_mirror_version.go
+++ b/internal/provider/datasource_terraform_mirror_version.go
@@ -1,0 +1,134 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorVersionDataSource{}
+
+type TerraformMirrorVersionDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorVersionPlatformModel struct {
+	OS   types.String `tfsdk:"os"`
+	Arch types.String `tfsdk:"arch"`
+	URL  types.String `tfsdk:"url"`
+}
+
+type TerraformMirrorVersionDataSourceModel struct {
+	MirrorID  types.String                          `tfsdk:"mirror_id"`
+	Version   types.String                          `tfsdk:"version"`
+	ID        types.String                          `tfsdk:"id"`
+	Stable    types.Bool                            `tfsdk:"stable"`
+	SyncedAt  types.String                          `tfsdk:"synced_at"`
+	Platforms []TerraformMirrorVersionPlatformModel `tfsdk:"platforms"`
+}
+
+func NewTerraformMirrorVersionDataSource() datasource.DataSource {
+	return &TerraformMirrorVersionDataSource{}
+}
+
+func (d *TerraformMirrorVersionDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_version"
+}
+
+func (d *TerraformMirrorVersionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Reads details for a single mirrored Terraform/OpenTofu version including available platforms.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string to look up.",
+				Required:    true,
+			},
+			"id": schema.StringAttribute{
+				Description: "Internal UUID of the version record.",
+				Computed:    true,
+			},
+			"stable": schema.BoolAttribute{
+				Description: "Whether this is a stable release.",
+				Computed:    true,
+			},
+			"synced_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when this version was synced.",
+				Computed:    true,
+			},
+			"platforms": schema.ListNestedAttribute{
+				Description: "Available platform builds for this version.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"os": schema.StringAttribute{
+							Description: "Operating system (e.g. 'linux', 'darwin').",
+							Computed:    true,
+						},
+						"arch": schema.StringAttribute{
+							Description: "Architecture (e.g. 'amd64', 'arm64').",
+							Computed:    true,
+						},
+						"url": schema.StringAttribute{
+							Description: "Download URL for this platform binary.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorVersionDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorVersionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorVersionDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	v, err := d.client.GetTerraformMirrorVersion(ctx, state.MirrorID.ValueString(), state.Version.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading Terraform Mirror Version", err.Error())
+		return
+	}
+
+	state.ID = types.StringValue(v.ID)
+	state.Stable = types.BoolValue(v.Stable)
+	if v.SyncedAt != nil {
+		state.SyncedAt = types.StringValue(normalizeTimestamp(*v.SyncedAt))
+	} else {
+		state.SyncedAt = types.StringValue("")
+	}
+
+	platforms := make([]TerraformMirrorVersionPlatformModel, 0, len(v.Platforms))
+	for _, p := range v.Platforms {
+		platforms = append(platforms, TerraformMirrorVersionPlatformModel{
+			OS:   types.StringValue(p.OS),
+			Arch: types.StringValue(p.Arch),
+			URL:  types.StringValue(p.URL),
+		})
+	}
+	state.Platforms = platforms
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/datasource_terraform_mirror_versions.go
+++ b/internal/provider/datasource_terraform_mirror_versions.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ datasource.DataSource = &TerraformMirrorVersionsDataSource{}
+
+type TerraformMirrorVersionsDataSource struct {
+	client *client.Client
+}
+
+type TerraformMirrorVersionsDataSourceModel struct {
+	MirrorID types.String                        `tfsdk:"mirror_id"`
+	Versions []TerraformMirrorVersionItemModel    `tfsdk:"versions"`
+}
+
+type TerraformMirrorVersionItemModel struct {
+	ID       types.String `tfsdk:"id"`
+	Version  types.String `tfsdk:"version"`
+	Stable   types.Bool   `tfsdk:"stable"`
+	SyncedAt types.String `tfsdk:"synced_at"`
+}
+
+func NewTerraformMirrorVersionsDataSource() datasource.DataSource {
+	return &TerraformMirrorVersionsDataSource{}
+}
+
+func (d *TerraformMirrorVersionsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_terraform_mirror_versions"
+}
+
+func (d *TerraformMirrorVersionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Lists all Terraform/OpenTofu versions mirrored by a given mirror configuration.",
+		Attributes: map[string]schema.Attribute{
+			"mirror_id": schema.StringAttribute{
+				Description: "UUID of the Terraform mirror configuration.",
+				Required:    true,
+			},
+			"versions": schema.ListNestedAttribute{
+				Description: "List of mirrored versions.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "Internal UUID of the version record.",
+							Computed:    true,
+						},
+						"version": schema.StringAttribute{
+							Description: "Semantic version string.",
+							Computed:    true,
+						},
+						"stable": schema.BoolAttribute{
+							Description: "Whether this is a stable release.",
+							Computed:    true,
+						},
+						"synced_at": schema.StringAttribute{
+							Description: "ISO 8601 timestamp when this version was synced.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *TerraformMirrorVersionsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	d.client = c
+}
+
+func (d *TerraformMirrorVersionsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state TerraformMirrorVersionsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	versions, err := d.client.ListTerraformMirrorVersions(ctx, state.MirrorID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Listing Terraform Mirror Versions", err.Error())
+		return
+	}
+
+	items := make([]TerraformMirrorVersionItemModel, 0, len(versions))
+	for _, v := range versions {
+		item := TerraformMirrorVersionItemModel{
+			ID:      types.StringValue(v.ID),
+			Version: types.StringValue(v.Version),
+			Stable:  types.BoolValue(v.Stable),
+		}
+		if v.SyncedAt != nil {
+			item.SyncedAt = types.StringValue(normalizeTimestamp(*v.SyncedAt))
+		} else {
+			item.SyncedAt = types.StringValue("")
+		}
+		items = append(items, item)
+	}
+
+	state.Versions = items
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -165,6 +165,7 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewModuleVersionDeprecationResource,
 		NewProviderVersionDeprecationResource,
 		NewOIDCGroupMappingResource,
+		NewStorageMigrationResource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,9 @@ import (
 var _ provider.Provider = &RegistryProvider{}
 var _ provider.ProviderWithFunctions = &RegistryProvider{}
 
+// minSupportedBackendVersion is the oldest backend version the provider is known to work with.
+const minSupportedBackendVersion = "1.0.0"
+
 // RegistryProvider implements the Terraform Registry provider.
 type RegistryProvider struct {
 	version string
@@ -25,11 +28,12 @@ type RegistryProvider struct {
 
 // RegistryProviderModel holds provider-level configuration.
 type RegistryProviderModel struct {
-	Endpoint   types.String `tfsdk:"endpoint"`
-	Token      types.String `tfsdk:"token"`
-	Insecure   types.Bool   `tfsdk:"insecure"`
-	Timeout    types.Int64  `tfsdk:"timeout"`
-	MaxRetries types.Int64  `tfsdk:"max_retries"`
+	Endpoint     types.String `tfsdk:"endpoint"`
+	Token        types.String `tfsdk:"token"`
+	Insecure     types.Bool   `tfsdk:"insecure"`
+	Timeout      types.Int64  `tfsdk:"timeout"`
+	MaxRetries   types.Int64  `tfsdk:"max_retries"`
+	VersionCheck types.Bool   `tfsdk:"version_check"`
 }
 
 // New returns a provider factory function.
@@ -69,6 +73,10 @@ func (p *RegistryProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			},
 			"max_retries": schema.Int64Attribute{
 				Description: "Maximum number of retries for failed requests (429, 5xx). Defaults to 3.",
+				Optional:    true,
+			},
+			"version_check": schema.BoolAttribute{
+				Description: "Probe the backend GET /version on configure and warn if the backend is older than the minimum supported version. Defaults to true. Set to false to disable.",
 				Optional:    true,
 			},
 		},
@@ -126,6 +134,11 @@ func (p *RegistryProvider) Configure(ctx context.Context, req provider.Configure
 	if err != nil {
 		resp.Diagnostics.AddError("Invalid Provider Configuration", err.Error())
 		return
+	}
+
+	skipVersionCheck := !config.VersionCheck.IsNull() && !config.VersionCheck.IsUnknown() && !config.VersionCheck.ValueBool()
+	if !skipVersionCheck {
+		probeBackendVersion(ctx, c, resp)
 	}
 
 	resp.DataSourceData = c

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,6 +161,9 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewStorageConfigResource,
 		NewPolicyResource,
 		NewApprovalRequestResource,
+		NewModuleDeprecationResource,
+		NewModuleVersionDeprecationResource,
+		NewProviderVersionDeprecationResource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,6 +191,11 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewAuditLogDataSource,
 		NewIdentityGroupMappingsDataSource,
 		NewMTLSConfigDataSource,
+		NewAdvisoriesDataSource,
+		NewScanningConfigDataSource,
+		NewScanningStatsDataSource,
+		NewScanDataSource,
+		NewModuleScanDataSource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -166,6 +166,7 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewProviderVersionDeprecationResource,
 		NewOIDCGroupMappingResource,
 		NewStorageMigrationResource,
+		NewModuleReanalyzeResource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,6 +188,9 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewTerraformMirrorHistoryDataSource,
 		NewPolicyEngineConfigDataSource,
 		NewPolicyEvaluationDataSource,
+		NewAuditLogDataSource,
+		NewIdentityGroupMappingsDataSource,
+		NewMTLSConfigDataSource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,7 @@ func (p *RegistryProvider) Resources(_ context.Context) []func() resource.Resour
 		NewModuleDeprecationResource,
 		NewModuleVersionDeprecationResource,
 		NewProviderVersionDeprecationResource,
+		NewOIDCGroupMappingResource,
 	}
 }
 
@@ -180,6 +181,7 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewRoleTemplatesDataSource,
 		NewAuditLogsDataSource,
 		NewStatsDataSource,
+		NewOIDCConfigDataSource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -182,6 +182,9 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewAuditLogsDataSource,
 		NewStatsDataSource,
 		NewOIDCConfigDataSource,
+		NewTerraformMirrorVersionsDataSource,
+		NewTerraformMirrorVersionDataSource,
+		NewTerraformMirrorHistoryDataSource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -185,6 +185,8 @@ func (p *RegistryProvider) DataSources(_ context.Context) []func() datasource.Da
 		NewTerraformMirrorVersionsDataSource,
 		NewTerraformMirrorVersionDataSource,
 		NewTerraformMirrorHistoryDataSource,
+		NewPolicyEngineConfigDataSource,
+		NewPolicyEvaluationDataSource,
 	}
 }
 

--- a/internal/provider/resource_module_deprecation.go
+++ b/internal/provider/resource_module_deprecation.go
@@ -1,0 +1,201 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ModuleDeprecationResource{}
+
+type ModuleDeprecationResource struct {
+	client *client.Client
+}
+
+type ModuleDeprecationResourceModel struct {
+	Namespace         types.String `tfsdk:"namespace"`
+	Name              types.String `tfsdk:"name"`
+	System            types.String `tfsdk:"system"`
+	Message           types.String `tfsdk:"message"`
+	SuccessorModuleID types.String `tfsdk:"successor_module_id"`
+	DeprecatedAt      types.String `tfsdk:"deprecated_at"`
+}
+
+func NewModuleDeprecationResource() resource.Resource {
+	return &ModuleDeprecationResource{}
+}
+
+func (r *ModuleDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_deprecation"
+}
+
+func (r *ModuleDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a module as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the module.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Module name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.StringAttribute{
+				Description: "Module system (provider name, e.g. 'aws').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"successor_module_id": schema.StringAttribute{
+				Description: "Optional UUID of the successor module (used by Terraform CLI ≥1.10 for replacement guidance).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the module was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ModuleDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ModuleDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.SuccessorModuleID.IsNull() && !plan.SuccessorModuleID.IsUnknown() {
+		v := plan.SuccessorModuleID.ValueString()
+		dreq.SuccessorModuleID = &v
+	}
+
+	mod, err := r.client.DeprecateModule(ctx, plan.Namespace.ValueString(), plan.Name.ValueString(), plan.System.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Module", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(plan, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mod, err := r.client.GetModule(ctx, state.Namespace.ValueString(), state.Name.ValueString(), state.System.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Module", err.Error())
+		return
+	}
+
+	if !mod.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(state, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.SuccessorModuleID.IsNull() && !plan.SuccessorModuleID.IsUnknown() {
+		v := plan.SuccessorModuleID.ValueString()
+		dreq.SuccessorModuleID = &v
+	}
+
+	mod, err := r.client.DeprecateModule(ctx, plan.Namespace.ValueString(), plan.Name.ValueString(), plan.System.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Module Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleDeprecationToModel(plan, mod))...)
+}
+
+func (r *ModuleDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ModuleDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateModule(ctx, state.Namespace.ValueString(), state.Name.ValueString(), state.System.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Module Deprecation", err.Error())
+	}
+}
+
+func moduleDeprecationToModel(ref ModuleDeprecationResourceModel, mod *client.Module) ModuleDeprecationResourceModel {
+	m := ModuleDeprecationResourceModel{
+		Namespace: types.StringValue(mod.Namespace),
+		Name:      types.StringValue(mod.Name),
+		System:    types.StringValue(mod.System),
+		Message:   ref.Message,
+	}
+	if mod.DeprecationMessage != nil {
+		m.Message = types.StringValue(*mod.DeprecationMessage)
+	}
+	if mod.SuccessorModuleID != nil {
+		m.SuccessorModuleID = types.StringValue(*mod.SuccessorModuleID)
+	} else {
+		m.SuccessorModuleID = types.StringNull()
+	}
+	if mod.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*mod.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}

--- a/internal/provider/resource_module_reanalyze.go
+++ b/internal/provider/resource_module_reanalyze.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ModuleReanalyzeResource{}
+
+type ModuleReanalyzeResource struct {
+	client *client.Client
+}
+
+type ModuleReanalyzeResourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Namespace types.String `tfsdk:"namespace"`
+	Name      types.String `tfsdk:"name"`
+	System    types.String `tfsdk:"system"`
+	Version   types.String `tfsdk:"version"`
+	Triggers  types.Map    `tfsdk:"triggers"`
+}
+
+func NewModuleReanalyzeResource() resource.Resource {
+	return &ModuleReanalyzeResource{}
+}
+
+func (r *ModuleReanalyzeResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_reanalyze"
+}
+
+func (r *ModuleReanalyzeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Triggers re-analysis of a module version (terraform-docs, scanning, SCM verification). Recreates whenever triggers change; otherwise no-op on subsequent applies.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Composite identifier: {namespace}/{name}/{system}/{version}.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"namespace": schema.StringAttribute{
+				Description: "Module namespace.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Module name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.StringAttribute{
+				Description: "Module system (provider name).",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Module version to reanalyze.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"triggers": schema.MapAttribute{
+				Description: "Arbitrary key-value map. Changing any value forces the reanalyze action to run again.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ModuleReanalyzeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ModuleReanalyzeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleReanalyzeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.ReanalyzeModuleVersion(ctx,
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Triggering Module Reanalyze", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(fmt.Sprintf("%s/%s/%s/%s",
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString()))
+
+	if plan.Triggers.IsNull() || plan.Triggers.IsUnknown() {
+		plan.Triggers = types.MapValueMust(types.StringType, map[string]attr.Value{})
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *ModuleReanalyzeResource) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {
+	// No-op: this resource has no server-side persistent state to read back.
+}
+
+func (r *ModuleReanalyzeResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+	// All attributes have RequiresReplace; Update is never called.
+}
+
+func (r *ModuleReanalyzeResource) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+	// Nothing to undo — analysis is idempotent.
+}

--- a/internal/provider/resource_module_version_deprecation.go
+++ b/internal/provider/resource_module_version_deprecation.go
@@ -1,0 +1,218 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ModuleVersionDeprecationResource{}
+
+type ModuleVersionDeprecationResource struct {
+	client *client.Client
+}
+
+type ModuleVersionDeprecationResourceModel struct {
+	Namespace         types.String `tfsdk:"namespace"`
+	Name              types.String `tfsdk:"name"`
+	System            types.String `tfsdk:"system"`
+	Version           types.String `tfsdk:"version"`
+	Message           types.String `tfsdk:"message"`
+	ReplacementSource types.String `tfsdk:"replacement_source"`
+	DeprecatedAt      types.String `tfsdk:"deprecated_at"`
+}
+
+func NewModuleVersionDeprecationResource() resource.Resource {
+	return &ModuleVersionDeprecationResource{}
+}
+
+func (r *ModuleVersionDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_module_version_deprecation"
+}
+
+func (r *ModuleVersionDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a specific module version as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the module.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "Module name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"system": schema.StringAttribute{
+				Description: "Module system (provider name, e.g. 'aws').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string of the module version to deprecate.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"replacement_source": schema.StringAttribute{
+				Description: "Optional replacement source address (used by Terraform CLI ≥1.10 for upgrade guidance).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the version was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ModuleVersionDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ModuleVersionDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.ReplacementSource.IsNull() && !plan.ReplacementSource.IsUnknown() {
+		v := plan.ReplacementSource.ValueString()
+		dreq.ReplacementSource = &v
+	}
+
+	mv, err := r.client.DeprecateModuleVersion(ctx,
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Module Version", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(plan, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mv, err := r.client.GetModuleVersion(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Module Version", err.Error())
+		return
+	}
+
+	if !mv.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(state, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateModuleRequest{
+		Message: plan.Message.ValueString(),
+	}
+	if !plan.ReplacementSource.IsNull() && !plan.ReplacementSource.IsUnknown() {
+		v := plan.ReplacementSource.ValueString()
+		dreq.ReplacementSource = &v
+	}
+
+	mv, err := r.client.DeprecateModuleVersion(ctx,
+		plan.Namespace.ValueString(), plan.Name.ValueString(),
+		plan.System.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Module Version Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, moduleVersionDeprecationToModel(plan, mv))...)
+}
+
+func (r *ModuleVersionDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ModuleVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateModuleVersion(ctx,
+		state.Namespace.ValueString(), state.Name.ValueString(),
+		state.System.ValueString(), state.Version.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Module Version Deprecation", err.Error())
+	}
+}
+
+func moduleVersionDeprecationToModel(ref ModuleVersionDeprecationResourceModel, mv *client.ModuleVersion) ModuleVersionDeprecationResourceModel {
+	m := ModuleVersionDeprecationResourceModel{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+		System:    ref.System,
+		Version:   types.StringValue(mv.Version),
+		Message:   ref.Message,
+	}
+	if mv.DeprecationMessage != nil {
+		m.Message = types.StringValue(*mv.DeprecationMessage)
+	}
+	if mv.ReplacementSource != nil {
+		m.ReplacementSource = types.StringValue(*mv.ReplacementSource)
+	} else {
+		m.ReplacementSource = types.StringNull()
+	}
+	if mv.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*mv.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}

--- a/internal/provider/resource_oidc_group_mapping.go
+++ b/internal/provider/resource_oidc_group_mapping.go
@@ -1,0 +1,204 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &OIDCGroupMappingResource{}
+
+type OIDCGroupMappingResource struct {
+	client *client.Client
+}
+
+type OIDCGroupMappingResourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	OIDCGroup      types.String `tfsdk:"oidc_group"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	RoleTemplateID types.String `tfsdk:"role_template_id"`
+}
+
+func NewOIDCGroupMappingResource() resource.Resource {
+	return &OIDCGroupMappingResource{}
+}
+
+func (r *OIDCGroupMappingResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_oidc_group_mapping"
+}
+
+func (r *OIDCGroupMappingResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a single OIDC group → organization role mapping. The backend stores mappings as a full-replace list; this resource reads the current list, adds or removes its entry, and writes the list back.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Composite identifier: {oidc_group}:{organization_id}.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"oidc_group": schema.StringAttribute{
+				Description: "OIDC groups claim value to match.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"organization_id": schema.StringAttribute{
+				Description: "UUID of the organization this mapping applies to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"role_template_id": schema.StringAttribute{
+				Description: "UUID of the role template to assign.",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *OIDCGroupMappingResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *OIDCGroupMappingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	entry := client.OIDCGroupMapping{
+		OIDCGroup:      plan.OIDCGroup.ValueString(),
+		OrganizationID: plan.OrganizationID.ValueString(),
+		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+	}
+
+	updated := upsertMapping(current, entry)
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(oidcMappingID(plan.OIDCGroup.ValueString(), plan.OrganizationID.ValueString()))
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *OIDCGroupMappingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	mappings, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	for _, m := range mappings {
+		if m.OIDCGroup == state.OIDCGroup.ValueString() && m.OrganizationID == state.OrganizationID.ValueString() {
+			state.RoleTemplateID = types.StringValue(m.RoleTemplateID)
+			resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+			return
+		}
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *OIDCGroupMappingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	entry := client.OIDCGroupMapping{
+		OIDCGroup:      plan.OIDCGroup.ValueString(),
+		OrganizationID: plan.OrganizationID.ValueString(),
+		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+	}
+
+	updated := upsertMapping(current, entry)
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *OIDCGroupMappingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state OIDCGroupMappingResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	current, err := r.client.GetOIDCGroupMappings(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		return
+	}
+
+	updated := removeMapping(current, state.OIDCGroup.ValueString(), state.OrganizationID.ValueString())
+	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
+	}
+}
+
+func oidcMappingID(group, orgID string) string {
+	return fmt.Sprintf("%s:%s", group, orgID)
+}
+
+func upsertMapping(current []client.OIDCGroupMapping, entry client.OIDCGroupMapping) []client.OIDCGroupMapping {
+	for i, m := range current {
+		if m.OIDCGroup == entry.OIDCGroup && m.OrganizationID == entry.OrganizationID {
+			current[i] = entry
+			return current
+		}
+	}
+	return append(current, entry)
+}
+
+func removeMapping(current []client.OIDCGroupMapping, group, orgID string) []client.OIDCGroupMapping {
+	result := make([]client.OIDCGroupMapping, 0, len(current))
+	for _, m := range current {
+		if m.OIDCGroup != group || m.OrganizationID != orgID {
+			result = append(result, m)
+		}
+	}
+	return result
+}

--- a/internal/provider/resource_provider_version_deprecation.go
+++ b/internal/provider/resource_provider_version_deprecation.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+var _ resource.Resource = &ProviderVersionDeprecationResource{}
+
+type ProviderVersionDeprecationResource struct {
+	client *client.Client
+}
+
+type ProviderVersionDeprecationResourceModel struct {
+	Namespace    types.String `tfsdk:"namespace"`
+	Type         types.String `tfsdk:"type"`
+	Version      types.String `tfsdk:"version"`
+	Message      types.String `tfsdk:"message"`
+	DeprecatedAt types.String `tfsdk:"deprecated_at"`
+}
+
+func NewProviderVersionDeprecationResource() resource.Resource {
+	return &ProviderVersionDeprecationResource{}
+}
+
+func (r *ProviderVersionDeprecationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_provider_version_deprecation"
+}
+
+func (r *ProviderVersionDeprecationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Marks a specific provider version as deprecated. Destroying this resource removes the deprecation.",
+		Attributes: map[string]schema.Attribute{
+			"namespace": schema.StringAttribute{
+				Description: "Namespace (organization name) owning the provider.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"type": schema.StringAttribute{
+				Description: "Provider type name (e.g. 'aws', 'azurerm').",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"version": schema.StringAttribute{
+				Description: "Semantic version string of the provider version to deprecate.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"message": schema.StringAttribute{
+				Description: "Deprecation message shown to users.",
+				Required:    true,
+			},
+			"deprecated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the version was deprecated.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ProviderVersionDeprecationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *ProviderVersionDeprecationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateProviderVersionRequest{
+		Message: plan.Message.ValueString(),
+	}
+
+	pv, err := r.client.DeprecateProviderVersion(ctx,
+		plan.Namespace.ValueString(), plan.Type.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Deprecating Provider Version", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(plan, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	pv, err := r.client.GetProviderVersion(ctx,
+		state.Namespace.ValueString(), state.Type.ValueString(), state.Version.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Provider Version", err.Error())
+		return
+	}
+
+	if !pv.Deprecated {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(state, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dreq := client.DeprecateProviderVersionRequest{
+		Message: plan.Message.ValueString(),
+	}
+
+	pv, err := r.client.DeprecateProviderVersion(ctx,
+		plan.Namespace.ValueString(), plan.Type.ValueString(), plan.Version.ValueString(), dreq)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Updating Provider Version Deprecation", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, providerVersionDeprecationToModel(plan, pv))...)
+}
+
+func (r *ProviderVersionDeprecationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ProviderVersionDeprecationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.client.UndeprecateProviderVersion(ctx,
+		state.Namespace.ValueString(), state.Type.ValueString(), state.Version.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error Removing Provider Version Deprecation", err.Error())
+	}
+}
+
+func providerVersionDeprecationToModel(ref ProviderVersionDeprecationResourceModel, pv *client.ProviderVersion) ProviderVersionDeprecationResourceModel {
+	m := ProviderVersionDeprecationResourceModel{
+		Namespace: ref.Namespace,
+		Type:      ref.Type,
+		Version:   types.StringValue(pv.Version),
+		Message:   ref.Message,
+	}
+	if pv.DeprecationMessage != nil {
+		m.Message = types.StringValue(*pv.DeprecationMessage)
+	}
+	if pv.DeprecatedAt != nil {
+		m.DeprecatedAt = types.StringValue(normalizeTimestamp(*pv.DeprecatedAt))
+	} else {
+		m.DeprecatedAt = types.StringValue("")
+	}
+	return m
+}

--- a/internal/provider/resource_storage_migration.go
+++ b/internal/provider/resource_storage_migration.go
@@ -1,0 +1,272 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+const (
+	migrationPollInterval  = 15 * time.Second
+	migrationDefaultTimeout = 60 * time.Minute
+)
+
+var _ resource.Resource = &StorageMigrationResource{}
+
+type StorageMigrationResource struct {
+	client *client.Client
+}
+
+type StorageMigrationResourceModel struct {
+	ID              types.String `tfsdk:"id"`
+	SourceConfigID  types.String `tfsdk:"source_config_id"`
+	TargetConfigID  types.String `tfsdk:"target_config_id"`
+	TimeoutMinutes  types.Int64  `tfsdk:"timeout_minutes"`
+	Status          types.String `tfsdk:"status"`
+	ObjectsTotal    types.Int64  `tfsdk:"objects_total"`
+	ObjectsMigrated types.Int64  `tfsdk:"objects_migrated"`
+	ObjectsFailed   types.Int64  `tfsdk:"objects_failed"`
+	StartedAt       types.String `tfsdk:"started_at"`
+	CompletedAt     types.String `tfsdk:"completed_at"`
+	Error           types.String `tfsdk:"error"`
+	CreatedAt       types.String `tfsdk:"created_at"`
+	UpdatedAt       types.String `tfsdk:"updated_at"`
+}
+
+func NewStorageMigrationResource() resource.Resource {
+	return &StorageMigrationResource{}
+}
+
+func (r *StorageMigrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_storage_migration"
+}
+
+func (r *StorageMigrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Triggers a one-shot storage backend migration. Create starts the job and polls until it reaches a terminal state. Update is blocked (any input change forces replacement). Delete attempts cancellation if the job is still running.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "UUID of the migration job.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"source_config_id": schema.StringAttribute{
+				Description: "UUID of the storage config to migrate from.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"target_config_id": schema.StringAttribute{
+				Description: "UUID of the storage config to migrate to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"timeout_minutes": schema.Int64Attribute{
+				Description: "Maximum time in minutes to wait for the migration to complete. Defaults to 60.",
+				Optional:    true,
+				Computed:    true,
+				Default:     int64default.StaticInt64(60),
+			},
+			"status": schema.StringAttribute{
+				Description: "Migration status: 'pending', 'running', 'succeeded', or 'failed'.",
+				Computed:    true,
+			},
+			"objects_total": schema.Int64Attribute{
+				Description: "Total number of objects to migrate.",
+				Computed:    true,
+			},
+			"objects_migrated": schema.Int64Attribute{
+				Description: "Number of objects successfully migrated.",
+				Computed:    true,
+			},
+			"objects_failed": schema.Int64Attribute{
+				Description: "Number of objects that failed to migrate.",
+				Computed:    true,
+			},
+			"started_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the migration started.",
+				Computed:    true,
+			},
+			"completed_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the migration completed.",
+				Computed:    true,
+			},
+			"error": schema.StringAttribute{
+				Description: "Error message if the migration failed.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the migration job was created.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "ISO 8601 timestamp when the migration job was last updated.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *StorageMigrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	c, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data", "Expected *client.Client")
+		return
+	}
+	r.client = c
+}
+
+func (r *StorageMigrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan StorageMigrationResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	m, err := r.client.CreateStorageMigration(ctx, client.CreateStorageMigrationRequest{
+		SourceConfigID: plan.SourceConfigID.ValueString(),
+		TargetConfigID: plan.TargetConfigID.ValueString(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Error Starting Storage Migration", err.Error())
+		return
+	}
+
+	timeout := migrationDefaultTimeout
+	if !plan.TimeoutMinutes.IsNull() && !plan.TimeoutMinutes.IsUnknown() {
+		timeout = time.Duration(plan.TimeoutMinutes.ValueInt64()) * time.Minute
+	}
+
+	m, err = r.pollMigration(ctx, m.ID, timeout)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Waiting For Migration", err.Error())
+		return
+	}
+
+	model := migrationToModel(m)
+	model.TimeoutMinutes = plan.TimeoutMinutes
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func (r *StorageMigrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state StorageMigrationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	m, err := r.client.GetStorageMigration(ctx, state.ID.ValueString())
+	if err != nil {
+		if client.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error Reading Storage Migration", err.Error())
+		return
+	}
+
+	model := migrationToModel(m)
+	model.TimeoutMinutes = state.TimeoutMinutes
+	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+}
+
+func (r *StorageMigrationResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+	// All mutable fields have RequiresReplace, so Update is never called.
+}
+
+func (r *StorageMigrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state StorageMigrationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	status := state.Status.ValueString()
+	if status == "pending" || status == "running" {
+		if _, err := r.client.CancelStorageMigration(ctx, state.ID.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Error Cancelling Storage Migration", err.Error())
+		}
+	}
+}
+
+// pollMigration polls until the migration reaches a terminal state or the timeout is exceeded.
+func (r *StorageMigrationResource) pollMigration(ctx context.Context, id string, timeout time.Duration) (*client.StorageMigration, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		m, err := r.client.GetStorageMigration(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		switch m.Status {
+		case "succeeded":
+			return m, nil
+		case "failed":
+			msg := "migration failed"
+			if m.Error != nil {
+				msg = *m.Error
+			}
+			return m, fmt.Errorf("%s", msg)
+		}
+
+		if time.Now().After(deadline) {
+			return m, fmt.Errorf("timed out after %s waiting for migration %s (status: %s)", timeout, id, m.Status)
+		}
+
+		select {
+		case <-ctx.Done():
+			return m, ctx.Err()
+		case <-time.After(migrationPollInterval):
+		}
+	}
+}
+
+func migrationToModel(m *client.StorageMigration) StorageMigrationResourceModel {
+	model := StorageMigrationResourceModel{
+		ID:              types.StringValue(m.ID),
+		SourceConfigID:  types.StringValue(m.SourceConfigID),
+		TargetConfigID:  types.StringValue(m.TargetConfigID),
+		Status:          types.StringValue(m.Status),
+		ObjectsTotal:    types.Int64Value(int64(m.ObjectsTotal)),
+		ObjectsMigrated: types.Int64Value(int64(m.ObjectsMigrated)),
+		ObjectsFailed:   types.Int64Value(int64(m.ObjectsFailed)),
+		CreatedAt:       types.StringValue(normalizeTimestamp(m.CreatedAt)),
+		UpdatedAt:       types.StringValue(normalizeTimestamp(m.UpdatedAt)),
+	}
+	if m.StartedAt != nil {
+		model.StartedAt = types.StringValue(normalizeTimestamp(*m.StartedAt))
+	} else {
+		model.StartedAt = types.StringValue("")
+	}
+	if m.CompletedAt != nil {
+		model.CompletedAt = types.StringValue(normalizeTimestamp(*m.CompletedAt))
+	} else {
+		model.CompletedAt = types.StringValue("")
+	}
+	if m.Error != nil {
+		model.Error = types.StringValue(*m.Error)
+	} else {
+		model.Error = types.StringValue("")
+	}
+	return model
+}

--- a/internal/provider/scan_model.go
+++ b/internal/provider/scan_model.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+// ScanFindingModel is the Terraform model for a scan finding.
+type ScanFindingModel struct {
+	ID          types.String `tfsdk:"id"`
+	RuleID      types.String `tfsdk:"rule_id"`
+	Severity    types.String `tfsdk:"severity"`
+	Title       types.String `tfsdk:"title"`
+	Description types.String `tfsdk:"description"`
+	Resource    types.String `tfsdk:"resource"`
+	FilePath    types.String `tfsdk:"file_path"`
+	LineNumber  types.Int64  `tfsdk:"line_number"`
+}
+
+// ScanDataModel holds the common attributes of a scan result.
+type ScanDataModel struct {
+	ID           types.String       `tfsdk:"id"`
+	Status       types.String       `tfsdk:"status"`
+	Scanner      types.String       `tfsdk:"scanner"`
+	Passed       types.Bool         `tfsdk:"passed"`
+	Findings     []ScanFindingModel `tfsdk:"findings"`
+	ExecutionLog types.String       `tfsdk:"execution_log"`
+	StartedAt    types.String       `tfsdk:"started_at"`
+	CompletedAt  types.String       `tfsdk:"completed_at"`
+	CreatedAt    types.String       `tfsdk:"created_at"`
+}
+
+func scanToModel(s *client.Scan) ScanDataModel {
+	m := ScanDataModel{
+		ID:        types.StringValue(s.ID),
+		Status:    types.StringValue(s.Status),
+		Scanner:   types.StringValue(s.Scanner),
+		Passed:    types.BoolValue(s.Passed),
+		CreatedAt: types.StringValue(normalizeTimestamp(s.CreatedAt)),
+	}
+	if s.ExecutionLog != nil {
+		m.ExecutionLog = types.StringValue(*s.ExecutionLog)
+	} else {
+		m.ExecutionLog = types.StringValue("")
+	}
+	if s.StartedAt != nil {
+		m.StartedAt = types.StringValue(normalizeTimestamp(*s.StartedAt))
+	} else {
+		m.StartedAt = types.StringValue("")
+	}
+	if s.CompletedAt != nil {
+		m.CompletedAt = types.StringValue(normalizeTimestamp(*s.CompletedAt))
+	} else {
+		m.CompletedAt = types.StringValue("")
+	}
+
+	findings := make([]ScanFindingModel, 0, len(s.Findings))
+	for _, f := range s.Findings {
+		fm := ScanFindingModel{
+			ID:       types.StringValue(f.ID),
+			RuleID:   types.StringValue(f.RuleID),
+			Severity: types.StringValue(f.Severity),
+			Title:    types.StringValue(f.Title),
+		}
+		opt := func(s *string) types.String {
+			if s != nil {
+				return types.StringValue(*s)
+			}
+			return types.StringValue("")
+		}
+		fm.Description = opt(f.Description)
+		fm.Resource = opt(f.Resource)
+		fm.FilePath = opt(f.FilePath)
+		if f.LineNumber != nil {
+			fm.LineNumber = types.Int64Value(int64(*f.LineNumber))
+		} else {
+			fm.LineNumber = types.Int64Value(0)
+		}
+		findings = append(findings, fm)
+	}
+	m.Findings = findings
+	return m
+}

--- a/internal/provider/semver.go
+++ b/internal/provider/semver.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type semver struct{ major, minor, patch int }
+
+// parseSemver parses a "vX.Y.Z" or "X.Y.Z" string.
+func parseSemver(s string) (semver, error) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return semver{}, fmt.Errorf("invalid semver %q", s)
+	}
+	var v semver
+	var err error
+	if v.major, err = strconv.Atoi(parts[0]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	if v.minor, err = strconv.Atoi(parts[1]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	if v.patch, err = strconv.Atoi(parts[2]); err != nil {
+		return semver{}, fmt.Errorf("invalid semver %q: %w", s, err)
+	}
+	return v, nil
+}
+
+// less reports whether v is strictly less than other.
+func (v semver) less(other semver) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	return v.patch < other.patch
+}

--- a/internal/provider/semver_test.go
+++ b/internal/provider/semver_test.go
@@ -1,0 +1,55 @@
+package provider
+
+import "testing"
+
+func TestParseSemver(t *testing.T) {
+	cases := []struct {
+		input   string
+		wantErr bool
+		major   int
+		minor   int
+		patch   int
+	}{
+		{"1.0.0", false, 1, 0, 0},
+		{"v1.2.3", false, 1, 2, 3},
+		{"0.9.99", false, 0, 9, 99},
+		{"bad", true, 0, 0, 0},
+		{"1.2", true, 0, 0, 0},
+	}
+	for _, tc := range cases {
+		got, err := parseSemver(tc.input)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseSemver(%q): expected error, got none", tc.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseSemver(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got.major != tc.major || got.minor != tc.minor || got.patch != tc.patch {
+			t.Errorf("parseSemver(%q) = %+v, want {%d %d %d}", tc.input, got, tc.major, tc.minor, tc.patch)
+		}
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.9.0", "1.0.0", true},
+		{"1.0.0", "1.0.0", false},
+		{"1.0.1", "1.0.0", false},
+		{"1.0.0", "1.0.1", true},
+		{"2.0.0", "1.9.9", false},
+	}
+	for _, tc := range cases {
+		a, _ := parseSemver(tc.a)
+		b, _ := parseSemver(tc.b)
+		if got := a.less(b); got != tc.want {
+			t.Errorf("%s < %s: got %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/provider/version_probe.go
+++ b/internal/provider/version_probe.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+)
+
+// probeBackendVersion calls GET /version and adds a warning diagnostic if the
+// backend is older than minSupportedBackendVersion or the endpoint is unreachable.
+func probeBackendVersion(ctx context.Context, c *client.Client, resp *provider.ConfigureResponse) {
+	bv, err := c.GetVersion(ctx)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Backend Version Check Failed",
+			fmt.Sprintf(
+				"Could not reach GET /version on the registry endpoint: %s. "+
+					"Verify the endpoint is correct and that /version is accessible. "+
+					"The provider will still attempt to operate normally.",
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	min, err := parseSemver(minSupportedBackendVersion)
+	if err != nil {
+		return
+	}
+
+	got, err := parseSemver(bv.Version)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Backend Version Unrecognized",
+			fmt.Sprintf(
+				"The backend reported version %q which could not be parsed as a semantic version. "+
+					"Minimum supported backend version is %s.",
+				bv.Version, minSupportedBackendVersion,
+			),
+		)
+		return
+	}
+
+	if got.less(min) {
+		resp.Diagnostics.AddWarning(
+			"Unsupported Backend Version",
+			fmt.Sprintf(
+				"The registry backend is running version %s, but this provider requires at least %s. "+
+					"Upgrade the backend to avoid API errors. "+
+					"Set version_check = false in the provider block to suppress this warning.",
+				bv.Version, minSupportedBackendVersion,
+			),
+		)
+	}
+}


### PR DESCRIPTION
Release v0.3.0 — all Tier 3 features from issues #52–#61.

### New resources
- registry_module_deprecation
- registry_module_version_deprecation
- registry_provider_version_deprecation
- registry_oidc_group_mapping
- registry_storage_migration
- registry_module_reanalyze

### New data sources
- data.registry_oidc_config
- data.registry_terraform_mirror_versions / _version / _history
- data.registry_policy_engine_config / _evaluation
- data.registry_audit_log
- data.registry_identity_group_mappings
- data.registry_mtls_config
- data.registry_advisories
- data.registry_scanning_config / _stats / _scan / _module_scan

### Provider
- Backend version probe on configure (GET /version); opt out with version_check = false

### Chore
- docker-compose.test.yml pinned to backend v1.0.0

See CHANGELOG.md [0.3.0] section.