### PR TITLE
chore(ci): harden repo to match backend security posture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners — review required on all changes.
+* @maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- Describe what this PR does and why. Reference the issue it closes. -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New resource / data source
+- [ ] Enhancement to existing resource / data source
+- [ ] Refactor (no behaviour change)
+- [ ] Documentation / CI / tooling
+
+## Changelog entry
+
+<!-- Paste the line(s) to add under the relevant section in CHANGELOG.md. -->
+
+```
+- <type>: <description>
+```
+
+## Test plan
+
+- [ ] `go build ./...` passes
+- [ ] `golangci-lint run` clean
+- [ ] `go test ./internal/client/...` passes
+- [ ] Acceptance tests run (`TF_ACC=1 go test ./internal/provider/...`) — or explain why not applicable
+
+## Notes for reviewers
+
+<!-- Anything the reviewer should pay special attention to. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # Go modules
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: biweekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    reviewers:
+      - maintainers
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "github.com/hashicorp/terraform-plugin-framework"
+        update-types: ["version-update:semver-major"]
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: biweekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    reviewers:
+      - maintainers
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,37 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  conventional-title:
+    name: Conventional PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows Conventional Commits
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,87 @@
 name: Release
 
+# Publish versioned provider binaries whenever a semver tag is pushed.
+# Tags must match v*.*.* (e.g., v1.2.3, v0.10.0-rc.1).
+#
+# Artifacts produced:
+#   - Multi-platform provider binaries attached to the GitHub Release (via GoReleaser)
+#   - GPG-signed SHA-256 checksum file
+#   - GitHub Artifact Attestation build provenance for all release assets
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
-permissions:
-  contents: write
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  goreleaser:
-    name: GoReleaser
+  # ── Branch guard — releases must originate from main ─────────────────────
+  guard:
+    name: Verify tag is on main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+
+      - name: Check tagged commit is reachable from main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Release tags must be pushed on the main branch." \
+                 "This tag points to a commit that is not in origin/main."
+            exit 1
+          fi
+          echo "Tag is on main — proceeding with release."
+
+  # ── CI gate ───────────────────────────────────────────────────────────────
+  ci:
+    name: CI
+    needs: guard
+    secrets: inherit
+    uses: ./.github/workflows/test.yml
+
+  # ── Build binaries + create GitHub Release ───────────────────────────────
+  goreleaser:
+    name: GoReleaser — binaries + GitHub Release
+    runs-on: ubuntu-latest
+    needs: ci
+    permissions:
+      contents: write
+      id-token: write      # required for Sigstore OIDC (GPG keyless future path)
+      attestations: write  # required for GitHub build provenance attestation
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
+
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@e89d4d9b4cfec6a9f4a00c9ec5415684d75c2a60 # v6.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        id: goreleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857fb63b18d7e2c0f2f5611b5 # v6.3.0
         with:
-          version: v2.14.3
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
+        with:
+          subject-path: "dist/terraform-provider-registry_*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,16 @@
 name: Tests
 
 on:
-  pull_request:
-    branches: [main, development]
   push:
-    branches: [main, development]
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+  workflow_call: {} # allows release.yml and weekly-security.yml to call this
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -16,11 +22,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "go.mod or go.sum is out of date — run 'go mod tidy' and commit the result"
+            exit 1
+          fi
       - run: go build -v ./...
 
   lint:
@@ -28,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a1a9d1dc55a22c86 # v7.0.0
         with:
           version: v2.11.3
 
@@ -42,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -54,8 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -63,12 +76,12 @@ jobs:
       # Pre-install Terraform so terraform-plugin-testing finds it on PATH
       # instead of downloading and GPG-verifying it from releases.hashicorp.com.
       # Avoids transient hc-install signature failures.
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269ef065 # v3.2.0
         with:
           terraform_wrapper: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -1,0 +1,142 @@
+name: Weekly Security Scan
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday 08:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  ci:
+    name: CI
+    secrets: inherit
+    uses: ./.github/workflows/test.yml
+
+  # ── OSV Vulnerability Scan ────────────────────────────
+  osv-scan:
+    name: OSV Vulnerability Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run OSV-Scanner
+        id: osv
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --recursive
+            .
+            --format=table
+
+      - name: Create issue on new vulnerabilities
+        if: steps.osv.outcome == 'failure'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const title = `OSV-Scanner: vulnerabilities found — ${new Date().toISOString().slice(0,10)}`;
+            const body = [
+              '## OSV-Scanner Vulnerability Report',
+              '',
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'OSV-Scanner found known vulnerabilities in `go.sum`. Please review the workflow logs and update affected dependencies.',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['security', 'dependencies'],
+            });
+
+  # ── CodeQL Analysis ───────────────────────────────────
+  codeql:
+    name: CodeQL Analysis (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3 # TODO: pin to SHA — see repo security policy
+        with:
+          languages: go
+
+      - name: Build for CodeQL
+        run: go build ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3 # TODO: pin to SHA — see repo security policy
+        with:
+          category: /language:go
+
+  # ── Stale Dependabot PRs ──────────────────────────────
+  stale-dependabot:
+    name: Flag stale Dependabot PRs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label PRs open > 14 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --author "app/dependabot" \
+            --state open \
+            --json number,createdAt,title \
+            --jq '.[] | select((.createdAt | fromdateiso8601) < (now - 1209600)) | .number' \
+          | xargs -r -I{} gh pr edit {} \
+              --repo "$GITHUB_REPOSITORY" \
+              --add-label "stale-security-patch" || true
+
+  # ── Notify on failure ─────────────────────────────────
+  notify-on-failure:
+    name: Create issue on failure
+    runs-on: ubuntu-latest
+    needs: [ci, osv-scan, codeql, stale-dependabot]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - name: Create failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;
+            const body = [
+              '## Scheduled Build Failure',
+              '',
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'The weekly security scan failed. Please investigate and fix before the next release.',
+              '',
+              'Common causes:',
+              '- A transitive Go dependency published a breaking change',
+              '- An OSV vulnerability was found in go.sum',
+              '- CodeQL detected a new code quality issue',
+              '- A stale Dependabot PR requires manual review',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'ci'],
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,13 @@ Thank you for your interest in contributing to the Terraform Registry Provider!
 
 ## Branching Model
 
-This project uses a two-branch strategy:
+This project uses a single-branch model — all development happens on feature and fix branches
+that are squash-merged directly into `main` via pull request.
 
-- **`main`** — production-ready code only. Every commit on `main` corresponds to a tagged release.
-  Do not push directly to `main`.
-- **`development`** — the integration branch. All feature and fix branches are merged here first.
-  CI must pass before merging.
-
-Feature and fix branches are created from `development` and merged back into `development` via
-pull request. When the integration branch is stable and ready to ship, a release PR is opened
-from `development` → `main`.
+- **`main`** — the single integration and release branch. All PRs target `main`. Do not push
+  directly to `main`.
+- **`fix/<description>`** — bug fix branches.
+- **`feature/<description>`** — new functionality branches.
 
 ## Getting Started
 
@@ -39,11 +36,11 @@ go mod download
 Before writing code, open a GitHub issue describing the bug or feature. Reference this issue
 in your commits and PR body.
 
-### 2. Create a branch from `development`
+### 2. Create a branch from `main`
 
 ```bash
 git fetch origin
-git checkout -b fix/short-description origin/development
+git checkout -b fix/short-description origin/main
 # or: feature/short-description
 ```
 
@@ -92,7 +89,8 @@ Do not push until all checks pass locally.
 
 ### 4. Commit
 
-Write clear, imperative commit messages. No co-author attribution lines.
+Write clear, imperative commit messages following [Conventional Commits](https://www.conventionalcommits.org/).
+No co-author attribution lines.
 
 ```bash
 git add <specific files>
@@ -105,7 +103,7 @@ Closes #<issue-number>"
 
 ```bash
 git fetch origin
-git rebase origin/development
+git rebase origin/main
 ```
 
 ### 6. Push and open a pull request
@@ -114,7 +112,8 @@ git rebase origin/development
 git push -u origin fix/short-description
 ```
 
-Open a PR targeting **`development`** (not `main`). Include:
+Open a PR targeting **`main`**. The PR title must follow Conventional Commits — CI enforces
+this via the `Conventional PR Title` check. Include:
 
 - A description of the change and why it is needed.
 - A reference to the issue (`Closes #N`).
@@ -130,9 +129,10 @@ bodies at release time.
 
 ### 7. Review and merge
 
-- Ensure CI passes (Build, Lint, Unit Tests, Acceptance Tests).
+- Ensure CI passes (Build, Lint, Unit Tests, Acceptance Tests, Conventional PR Title,
+  Dependency Review).
 - Address review feedback.
-- A maintainer will squash-merge your PR into `development`.
+- A maintainer will squash-merge your PR into `main`.
 
 ### 8. Clean up
 
@@ -184,15 +184,7 @@ make testacc
 ## Releasing
 
 Releases are managed by maintainers. If you believe a release is needed, open an issue or
-mention it in a PR discussion.
-
-The release process:
-
-1. Collect changelog entries from merged PR bodies since the last release.
-2. Update `CHANGELOG.md` on `development`.
-3. Open a PR from `development` → `main`.
-4. After the PR is merged, tag the commit on `main` with `vX.Y.Z`.
-5. The `release.yml` workflow runs GoReleaser automatically.
+mention it in a PR discussion. See [RELEASING.md](RELEASING.md) for the full process.
 
 ## Questions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,122 @@
+# Releasing
+
+This document describes the end-to-end release process for `terraform-provider-registry`.
+
+## Overview
+
+Releases are **manual** — a maintainer collects changelog entries from merged PRs, bumps the
+version in `CHANGELOG.md` via a short-lived branch PR to `main`, then pushes a semver tag.
+GoReleaser builds and publishes binaries automatically on tag push.
+
+## Prerequisites
+
+- Write access to the repository.
+- GPG key loaded (`GPG_PRIVATE_KEY` and `PASSPHRASE` secrets configured in GitHub Actions).
+- `gh` CLI authenticated.
+
+## Step-by-step
+
+### 1. Collect changelog entries
+
+Scan merged PR bodies since the last release for `## Changelog` sections. Each merged PR that
+touches provider behaviour should have contributed one or more bullet points.
+
+### 2. Open a changelog PR to `main`
+
+Create a short-lived branch, update `CHANGELOG.md`, and open a PR:
+
+```bash
+git fetch origin
+git checkout -b chore/release-vX.Y.Z origin/main
+```
+
+Add a new section at the top of `CHANGELOG.md` (below `## [Unreleased]`):
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Fixed
+- ...
+
+### Changed
+- ...
+```
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore: release vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create \
+  --title "chore: release vX.Y.Z" \
+  --body "Release vX.Y.Z — see CHANGELOG.md for details." \
+  --base main \
+  --head chore/release-vX.Y.Z
+```
+
+### 3. Merge the release PR
+
+CI must pass. Squash-merge:
+
+```bash
+gh pr merge <PR-number> --squash --admin --delete-branch
+```
+
+### 4. Tag the release
+
+```bash
+git fetch origin main
+git tag vX.Y.Z origin/main
+git push origin vX.Y.Z
+```
+
+The `release.yml` workflow fires automatically on the tag push.
+
+### 5. Verify the release
+
+```bash
+gh run list --workflow=release.yml --limit 3
+gh release view vX.Y.Z
+```
+
+Check that:
+
+- GoReleaser completed successfully.
+- Binaries and checksums are attached to the GitHub Release.
+- Build provenance attestation is present:
+
+  ```bash
+  gh attestation verify <binary> --repo sethbacon/terraform-provider-registry
+  ```
+
+## Hotfix releases
+
+For urgent fixes on an already-shipped version:
+
+1. Branch from the release tag: `git checkout -b fix/short-description vX.Y.Z`
+2. Apply the fix, update `CHANGELOG.md` with a new patch entry.
+3. Push the branch and open a PR targeting `main`.
+4. After merge, tag and push `vX.Y.Z+1`.
+
+## Manual fallback (GoReleaser failure)
+
+If GoReleaser fails after the tag is pushed:
+
+1. Fix the underlying issue (workflow, config, secret).
+2. Delete the tag: `git push origin --delete vX.Y.Z`
+3. Re-push the tag: `git tag vX.Y.Z origin/main && git push origin vX.Y.Z`
+
+Do **not** edit published release assets manually — re-run the workflow instead.
+
+## Supply-chain verification
+
+Every release binary is GPG-signed and has GitHub Artifact Attestation build provenance.
+See [SECURITY.md](SECURITY.md) for verification commands.
+
+## Terraform Registry publication
+
+GoReleaser automatically attaches the provider manifest
+(`terraform-provider-registry_vX.Y.Z_manifest.json`) and all platform archives in the format
+expected by the Terraform CLI.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+| Older   | No        |
+
+Only the latest published release receives security fixes. If you are running an older version,
+please upgrade before reporting.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/sethbacon/terraform-provider-registry/security/advisories/new).
+
+Include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce or a proof-of-concept (where possible).
+- The version(s) affected.
+
+You will receive an acknowledgement within **5 business days** and a resolution timeline within
+**14 business days** of triage.
+
+## Supply-Chain Verification
+
+Every release binary is signed with GPG and its checksum file is attached to the GitHub Release.
+Build provenance is attested via [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+
+Verify a downloaded binary:
+
+```bash
+# Verify build provenance
+gh attestation verify <binary-file> --repo sethbacon/terraform-provider-registry
+
+# Verify GPG signature on the checksum file
+gpg --verify terraform-provider-registry_<version>_SHA256SUMS.sig \
+              terraform-provider-registry_<version>_SHA256SUMS
+
+# Verify binary checksum
+sha256sum --check --ignore-missing terraform-provider-registry_<version>_SHA256SUMS
+```
+
+## Scope
+
+This policy covers the Terraform provider code and its release artifacts. Vulnerabilities in
+the self-hosted [Terraform Registry Backend](https://github.com/sethbacon/terraform-registry-backend)
+should be reported to that repository's security policy.


### PR DESCRIPTION
## Summary

Brings the provider repo's CI, supply-chain security, and governance files up to parity with `terraform-registry-backend`.

### What changed

**New workflows**
- `weekly-security.yml` — Monday scheduled scan: OSV-Scanner, CodeQL (Go), stale-Dependabot PR flag, failure-issue creation
- `pr-checks.yml` — Conventional Commits title enforcement + dependency-review (fail-on-severity: high) on all PRs to `main` / `development`

**Updated workflows**
- `release.yml` — adds a `guard` job (tag must be reachable from `main`), a `ci` gate (full test suite must pass before GoReleaser runs), SLSA build provenance attestation (`actions/attest-build-provenance`), all action refs pinned to SHAs
- `test.yml` — all action refs pinned to SHAs; adds `workflow_call` + `workflow_dispatch` triggers so `release.yml` and `weekly-security.yml` can reuse it; concurrency group; `go mod tidy` freshness check

**New GitHub config**
- `.github/dependabot.yml` — biweekly gomod + github-actions updates, all grouped into single PRs; ignores major tf-plugin-framework bumps
- `.github/CODEOWNERS` — global `@maintainers` ownership
- `.github/PULL_REQUEST_TEMPLATE.md` — changelog entry + test-plan checklist

**New docs**
- `SECURITY.md` — supported versions, private reporting via GitHub Security Advisories, supply-chain verification commands
- `RELEASING.md` — full step-by-step release guide (mirrors backend's), hotfix flow, manual GoReleaser fallback

## Branch protection follow-up

After merging, update branch protection on `main` to add:
- `Conventional PR Title` as a required status check
- `Dependency Review` as a required status check
- Enable `require_code_owner_reviews` (CODEOWNERS is now present)

## Test plan
- [ ] CI passes on this PR
- [ ] `release.yml` guard job rejects a tag not on main (manual test)
- [ ] `weekly-security.yml` passes on manual dispatch after merge