### PR TITLE
fix(ci): correct pinned action SHAs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v5.5.3
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@e89d4d9b4cfec6a9f4a00c9ec5415684d75c2a60 # v6.3.0
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857fb63b18d7e2c0f2f5611b5 # v6.3.0
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: "~> v2"
           args: release --clean
@@ -82,6 +82,6 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: "dist/terraform-provider-registry_*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a1a9d1dc55a22c86 # v7.0.0
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: v2.11.3
 
@@ -76,7 +76,7 @@ jobs:
       # Pre-install Terraform so terraform-plugin-testing finds it on PATH
       # instead of downloading and GPG-verifying it from releases.hashicorp.com.
       # Avoids transient hc-install signature failures.
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269ef065 # v3.2.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_wrapper: false
 


### PR DESCRIPTION
Several action SHAs written in the repo-hardening commit were incorrect (typos or non-existent patch versions). Fixes the failures seen in the manual Tests workflow dispatch.

## Changes
- `hashicorp/setup-terraform`: v3.2.0 does not exist → corrected to v3.1.2 (`b9cd54a...862dd`)
- `golangci/golangci-lint-action`: corrected to v7.0.1 SHA
- `crazy-max/ghaction-import-gpg`: corrected v6.3.0 SHA
- `goreleaser/goreleaser-action`: corrected v6.3.0 SHA
- `actions/attest-build-provenance`: corrected to v2.4.0 SHA
- `amannn/action-semantic-pull-request`: corrected v5.5.3 SHA
- `actions/dependency-review-action`: corrected to v4.6.0 SHA

## Changelog
- fix(ci): correct pinned action SHAs in test.yml, release.yml, and pr-checks.yml