### PR TITLE
fix(lint): add .gitattributes and fix gofmt on resource_storage_migration.go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Normalize line endings to LF in the repository.
+# This prevents gofmt from reporting formatting issues on Windows checkouts
+# where Git autocrlf converts LF → CRLF.
+* text=auto eol=lf
+
+# Go source files must always be LF.
+*.go text eol=lf
+
+# YAML/JSON/Markdown — keep LF.
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+
+# Shell scripts — LF required for execution on Linux/macOS.
+*.sh text eol=lf
+
+# Windows batch files are the one exception.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binaries — no line ending conversion.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.gz binary
+*.tar binary

--- a/internal/provider/resource_storage_migration.go
+++ b/internal/provider/resource_storage_migration.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	migrationPollInterval  = 15 * time.Second
+	migrationPollInterval   = 15 * time.Second
 	migrationDefaultTimeout = 60 * time.Minute
 )
 


### PR DESCRIPTION
Two changes:

- Add `.gitattributes` enforcing LF line endings for `*.go`, `*.yml`, `*.md` etc. Prevents future CRLF bleed from Windows checkouts.
- Fix gofmt const alignment in `resource_storage_migration.go` (misaligned `migrationPollInterval` vs `migrationDefaultTimeout`).

## Changelog
- fix(lint): add .gitattributes (LF enforcement) and fix gofmt in resource_storage_migration.go