### PR TITLE
perf(ci): shard acceptance tests across 4 parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,30 @@ jobs:
           cache: true
       - run: go test -v -count=1 -timeout 10m ./internal/client/...
 
-  acc-tests:
-    name: Acceptance Tests
+  # Acceptance tests are sharded across 4 parallel jobs to cut wall-clock time.
+  # Each shard runs its own isolated Docker stack on a fresh runner — no shared
+  # state between shards. Partition is by test-name regex, balanced by observed
+  # runtime so each shard finishes in roughly equal time (~10–12 min).
+  acc-tests-matrix:
+    name: Acceptance Tests / ${{ matrix.shard.id }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          # Heavy resource tests (creation-intensive). ~600s.
+          - id: shard-1
+            run: "^(TestAccModuleSCMLink_basic|TestAccOrganizationMember_basic|TestAccPolicy_basic)$"
+          # Mid-heavy resource tests. ~600s.
+          - id: shard-2
+            run: "^(TestAccModule_basic|TestAccProviderRecord_basic|TestAccTerraformMirror_basic|TestAccMirror_basic|TestAccUser_basic)$"
+          # Mixed mediums. ~720s.
+          - id: shard-3
+            run: "^(TestAccAPIKey_basic|TestAccApprovalRequest_basic|TestAccOrganization_basic|TestAccRoleTemplate_basic|TestAccDataProviders_basic|TestAccSCMProvider_basic|TestAccStorageConfig_basic)$"
+          # Data-source tests (lightweight, mostly 60s each). ~600s.
+          - id: shard-4
+            run: "^(TestAccDataAPIKeys_basic|TestAccDataAuditLogs_basic|TestAccDataMirrors_basic|TestAccDataModules_basic|TestAccDataOrganizations_basic|TestAccDataRoleTemplates_basic|TestAccDataSCMProviders_basic|TestAccDataStats_basic|TestAccDataTerraformMirrors_basic|TestAccDataUsers_basic)$"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -111,12 +131,29 @@ jobs:
             psql -U registry -d terraform_registry \
             < deployments/seed-dev-admin.sql
 
-      - name: Run acceptance tests
+      - name: Run acceptance tests (${{ matrix.shard.id }})
         env:
           TF_ACC: "1"
           TF_REGISTRY_ENDPOINT: "http://localhost:8081"
-        run: go test -v -count=1 -timeout 50m ./internal/provider/...
+        run: go test -v -count=1 -timeout 25m -run '${{ matrix.shard.run }}' ./internal/provider/...
 
       - name: Dump backend logs on failure
         if: failure()
         run: docker compose -f deployments/docker-compose.test.yml logs backend
+
+  # Aggregator job — keeps a single required check ("Acceptance Tests") for
+  # branch protection so we don't have to update protection rules when shards
+  # are added or rebalanced. Fails if any shard failed or was skipped.
+  acc-tests:
+    name: Acceptance Tests
+    runs-on: ubuntu-latest
+    needs: acc-tests-matrix
+    if: always()
+    steps:
+      - name: Verify all shards succeeded
+        run: |
+          if [ "${{ needs.acc-tests-matrix.result }}" != "success" ]; then
+            echo "One or more acceptance-test shards failed: ${{ needs.acc-tests-matrix.result }}"
+            exit 1
+          fi
+          echo "All acceptance-test shards passed."


### PR DESCRIPTION
## Summary

- Split the single \`Acceptance Tests\` job into a 4-way matrix; each shard runs its own isolated Docker stack on a fresh runner.
- Partition is by test-name regex, balanced by observed runtime so each shard finishes in roughly equal time.
- Adds an aggregator job named \`Acceptance Tests\` that depends on all shards — keeps the existing branch-protection required check intact (no protection-rule changes needed).

## Why

The acceptance test job was taking ~40 min for 25 tests because:

- Each \`TestStep\` carries ~60s of framework overhead (init / plan / apply / refresh / destroy) regardless of test logic.
- Tests have no \`t.Parallel()\`, so \`go test\` runs them serially — the runner's CPU sits idle most of the time.
- The 60s/120s/180s/300s test runtimes scale linearly with step count, confirming the cost is per-step framework overhead, not test logic.

Sharding across 4 runners trades a small amount of CI minutes (4× docker image pulls + setup) for a ~4× wall-clock speedup. Expected: ~10–12 min.

## Approach

- 25 tests partitioned into 4 shards by name regex; partitions verified to cover each test exactly once.
- Each shard's regex is anchored (\`^...$\`) so a future test name doesn't accidentally land in two shards.
- Shard timeouts dropped from 60 → 25 min since each shard runs ≤ ~12 min.
- \`fail-fast: false\` so one shard's failure doesn't mask issues in the others.

## Test plan

- [ ] PR CI runs all four \`Acceptance Tests / shard-N\` jobs in parallel and they complete in ~10–12 min.
- [ ] Aggregator \`Acceptance Tests\` job passes when all shards pass.
- [ ] Branch protection on \`main\` still recognizes the \`Acceptance Tests\` required check.

## Follow-ups (not in this PR)

- Add \`t.Parallel()\` to acceptance tests to also exploit intra-shard parallelism. Requires renaming several hardcoded resource names (\`acc-test-org\`, \`acc-apikey-org\`, etc.) to suffix-randomized variants first to avoid collisions.
- Audit \`registry_storage_config\` test for global-singleton behavior before parallelizing.