### PR TITLE
docs(readme): align with current resource set, schema, and branch model

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ HOSTNAME     = registry.terraform.io
 NAMESPACE    = terraform-registry
 NAME         = registry
 BINARY       = terraform-provider-${NAME}
-VERSION      = 0.2.0
+VERSION      = 0.3.1
 OS_ARCH      = $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     registry = {
       source  = "sethbacon/registry"
-      version = "~> 0.2"
+      version = "~> 0.3"
     }
   }
 }
@@ -28,6 +28,12 @@ terraform {
 provider "registry" {
   endpoint = "https://registry.example.com"
   token    = var.registry_token
+
+  # Optional tuning knobs:
+  # insecure      = false  # disable TLS cert verification (dev only)
+  # timeout       = 30     # HTTP request timeout in seconds
+  # max_retries   = 3      # retries for 429 / 5xx responses
+  # version_check = true   # warn if backend is older than the minimum supported version
 }
 
 variable "registry_token" {
@@ -44,12 +50,25 @@ export TF_REGISTRY_ENDPOINT="https://registry.example.com"
 export TF_REGISTRY_TOKEN="tfr_..."
 ```
 
+### Provider configuration reference
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `endpoint` | string | Base URL of the registry backend. Falls back to `TF_REGISTRY_ENDPOINT`. |
+| `token` | string (sensitive) | API key or JWT bearer token. Falls back to `TF_REGISTRY_TOKEN`. |
+| `insecure` | bool | Disable TLS certificate verification. Development only. Default `false`. |
+| `timeout` | int | HTTP request timeout in seconds. Default `30`. |
+| `max_retries` | int | Retries for `429` and `5xx` responses. Default `3`. |
+| `version_check` | bool | Probe the backend's `GET /version` and warn if it is older than the minimum supported. Default `true`. |
+
 ## Documentation
 
 Full provider documentation is available on the
 [Terraform Registry](https://registry.terraform.io/providers/sethbacon/registry/latest/docs).
 
 ### Resources
+
+#### Identity and access
 
 | Resource | Description |
 | --- | --- |
@@ -58,29 +77,71 @@ Full provider documentation is available on the
 | `registry_organization_member` | User membership and role within an organization |
 | `registry_api_key` | Scoped API key for CI/CD and automation |
 | `registry_role_template` | Custom RBAC role template |
+| `registry_oidc_group_mapping` | Maps an external IdP group to a registry role |
+
+#### Modules and providers
+
+| Resource | Description |
+| --- | --- |
 | `registry_module` | Module record |
-| `registry_provider_record` | Provider record |
+| `registry_module_deprecation` | Deprecation marker for an entire module |
+| `registry_module_version_deprecation` | Deprecation marker for a single module version |
+| `registry_module_reanalyze` | Trigger re-scanning / re-analysis of a module version |
 | `registry_module_scm_link` | SCM-to-module link for automatic version publishing |
+| `registry_provider_record` | Provider record |
+| `registry_provider_version_deprecation` | Deprecation marker for a single provider version |
 | `registry_scm_provider` | SCM integration (GitHub, GitLab, Azure DevOps, Bitbucket) |
+
+#### Mirroring, storage, and policy
+
+| Resource | Description |
+| --- | --- |
 | `registry_mirror` | Provider network mirror configuration |
 | `registry_terraform_mirror` | Terraform/OpenTofu binary mirror configuration |
 | `registry_storage_config` | Storage backend configuration (local, S3, Azure Blob, GCS) |
+| `registry_storage_migration` | Migrate existing artifacts between storage backends |
 | `registry_policy` | Mirror approval policy |
 | `registry_approval_request` | Mirror approval request |
 
 ### Data Sources
+
+#### Identity and access (data sources)
 
 | Data Source | Description |
 | --- | --- |
 | `registry_users` | List users |
 | `registry_organizations` | List organizations |
 | `registry_api_keys` | List API keys |
+| `registry_role_templates` | List role templates |
+| `registry_identity_group_mappings` | List IdP group → role mappings |
+| `registry_oidc_config` | Current OIDC SSO configuration |
+| `registry_mtls_config` | Current mTLS configuration |
+
+#### Modules, providers, and SCM (data sources)
+
+| Data Source | Description |
+| --- | --- |
 | `registry_modules` | List module records |
 | `registry_providers` | List provider records |
 | `registry_scm_providers` | List SCM integrations |
+| `registry_advisories` | Security advisories applicable to registry artifacts |
+| `registry_scan` | Result of a single scan run |
+| `registry_module_scan` | Latest scan result for a module version |
+| `registry_scanning_config` | Current scanning configuration |
+| `registry_scanning_stats` | Aggregated scanning statistics |
+
+#### Mirroring, policy, and observability (data sources)
+
+| Data Source | Description |
+| --- | --- |
 | `registry_mirrors` | List provider mirrors |
 | `registry_terraform_mirrors` | List Terraform/OpenTofu binary mirrors |
-| `registry_role_templates` | List role templates |
+| `registry_terraform_mirror_history` | History of binary mirror sync operations |
+| `registry_terraform_mirror_version` | Single Terraform/OpenTofu binary mirror version |
+| `registry_terraform_mirror_versions` | Versions available in a Terraform/OpenTofu binary mirror |
+| `registry_policy_engine_config` | Current policy engine configuration |
+| `registry_policy_evaluation` | Result of a policy evaluation |
+| `registry_audit_log` | A single audit log entry by ID |
 | `registry_audit_logs` | Query audit log entries |
 | `registry_stats` | Registry dashboard statistics |
 
@@ -156,9 +217,15 @@ go build ./...
 make install
 ```
 
-This installs the provider binary into `~/.terraform.d/plugins/` so it can be
-used with a local `terraform` configuration that references
+This installs the provider binary into the local Terraform plugin directory
+(`~/.terraform.d/plugins/registry.terraform.io/terraform-registry/registry/<version>/<os_arch>/`)
+so it can be used by a local `terraform` configuration that references
 `registry.terraform.io/terraform-registry/registry`.
+
+The `terraform-registry` namespace is a local-only convention used by the
+`make install` workflow for development. Released versions are published to
+the public Terraform Registry under `sethbacon/registry` (the source path
+shown in the `required_providers` block above).
 
 ### Running tests
 
@@ -172,7 +239,7 @@ Acceptance tests require a running registry backend. The easiest way is to use
 the included test stack:
 
 ```shell
-# Start the backend (pulls ghcr.io/sethbacon/terraform-registry-backend:latest)
+# Start the backend (pulls a pinned ghcr.io/sethbacon/terraform-registry-backend tag)
 docker compose -f deployments/docker-compose.test.yml up -d
 
 # Seed the dev admin user (run once per fresh database)
@@ -199,11 +266,12 @@ make docs
 
 ## Contributing
 
-This project uses a `main` / `development` two-branch model. All changes go through
-`development` first; only release PRs merge to `main`.
+This project uses a single-branch model: all `fix/*` and `feature/*` branches
+are squash-merged directly into `main` via pull request.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow: branching conventions,
-local quality gate, commit style, PR checklist, and the release process.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow — branching
+conventions, local quality gate, commit style, PR checklist — and
+[RELEASING.md](RELEASING.md) for the release process.
 
 ## License
 


### PR DESCRIPTION
## Summary

Bring \`README.md\` and \`GNUmakefile\` back in sync with the actual provider:

- **Version constraint**: \`~> 0.2\` → \`~> 0.3\` so the published \`v0.3.0\` is in range.
- **Provider config**: document the four optional arguments (\`insecure\`, \`timeout\`, \`max_retries\`, \`version_check\`) that were missing from both the example and the docs.
- **Resources / data sources tables**: add the 6 resources and 14 data sources that exist in the provider but were absent from the README. Both tables are now grouped by area (identity, modules/providers, mirroring/policy).
- **Source path clarification**: explain that \`registry.terraform.io/terraform-registry/registry\` is a local-dev convention from \`make install\`; released versions live at \`sethbacon/registry\`.
- **Branch model**: replace the stale \"main / development two-branch model\" note with the single-branch flow that's been in use since the migration earlier this cycle. \`CONTRIBUTING.md\` already reflects this — only the README was lagging.
- **GNUmakefile**: bump \`VERSION\` from \`0.2.0\` to \`0.3.1\` so \`make install\` drops the binary into a path matching the upcoming patch release.
- **Test-stack note**: stop saying \`docker compose up\` pulls \`:latest\`; the compose file pins a specific tag.

## Why

Several user-visible README claims were factually incorrect (version constraint, branch model) or incomplete (missing resources/data sources, undocumented provider config args). Worth a patch release so registry.terraform.io shows the corrected README.

## Test plan

- [ ] Markdownlint clean (no \`MD036\` emphasis-as-heading warnings; verified locally).
- [ ] Resource and data source tables match \`provider.go\` Resources/DataSources lists exactly.
- [ ] All listed provider config arguments match the schema in \`internal/provider/provider.go\`.
- [ ] CI green.