### PR TITLE
fix(client): GetModuleVersion derives state from module detail

### DIFF
--- a/internal/client/module_deprecations.go
+++ b/internal/client/module_deprecations.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 // DeprecateModule sets module-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/deprecate.
@@ -21,13 +22,43 @@ func (c *Client) UndeprecateModule(ctx context.Context, namespace, name, system 
 }
 
 // GetModuleVersion fetches a single module version for inspecting deprecation state.
+//
+// The backend has never exposed a dedicated `/api/v1/modules/{ns}/{name}/{sys}/{version}`
+// endpoint — every version-scoped route lives under `.../versions/{version}/...`. This
+// function therefore derives the version-level state from the module-detail response
+// (`GET /api/v1/modules/{ns}/{name}/{sys}`), which already returns the full versions
+// list. Doing it this way keeps the provider working against every backend release
+// shipped to date, regardless of whether a future dedicated endpoint is added.
+//
+// Errors:
+//   - module not found: the `*APIError` (404) from the underlying GET is propagated.
+//   - module found but version not in list: returns a synthetic `*APIError` with
+//     status 404 so that `IsNotFound` recognises it.
 func (c *Client) GetModuleVersion(ctx context.Context, namespace, name, system, version string) (*ModuleVersion, error) {
-	var mv ModuleVersion
-	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s/%s", namespace, name, system, version)
-	if err := c.Get(ctx, path, &mv); err != nil {
+	var detail moduleDetailResponse
+	path := fmt.Sprintf("/api/v1/modules/%s/%s/%s", namespace, name, system)
+	if err := c.Get(ctx, path, &detail); err != nil {
 		return nil, err
 	}
-	return &mv, nil
+
+	for i := range detail.Versions {
+		if detail.Versions[i].Version == version {
+			mv := detail.Versions[i]
+			return &mv, nil
+		}
+	}
+
+	return nil, &APIError{
+		StatusCode: http.StatusNotFound,
+		Message:    fmt.Sprintf("module version %s/%s/%s@%s not found", namespace, name, system, version),
+	}
+}
+
+// moduleDetailResponse mirrors the backend `admin.ModuleDetailResponse` payload
+// returned by `GET /api/v1/modules/{ns}/{name}/{sys}`. Only the fields we
+// actually consume are declared; unknown fields are ignored by the decoder.
+type moduleDetailResponse struct {
+	Versions []ModuleVersion `json:"versions"`
 }
 
 // DeprecateModuleVersion sets version-level deprecation via POST /api/v1/modules/{ns}/{name}/{sys}/versions/{ver}/deprecate.

--- a/internal/client/module_deprecations_test.go
+++ b/internal/client/module_deprecations_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetModuleVersion_FoundReturnsDeprecationFields verifies that the
+// defensive lookup picks the correct entry out of the module-detail
+// `versions[]` payload and surfaces the deprecation-related fields.
+func TestGetModuleVersion_FoundReturnsDeprecationFields(t *testing.T) {
+	expectedPath := "/api/v1/modules/acme/vpc/aws"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != expectedPath {
+			t.Errorf("unexpected request path: got %q, want %q", r.URL.Path, expectedPath)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "11111111-1111-1111-1111-111111111111",
+			"namespace": "acme",
+			"name": "vpc",
+			"system": "aws",
+			"versions": [
+				{
+					"id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					"version": "1.0.0",
+					"deprecated": false
+				},
+				{
+					"id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+					"version": "1.1.0",
+					"deprecated": true,
+					"deprecated_at": "2026-05-01T00:00:00Z",
+					"deprecation_message": "use 1.2.0",
+					"replacement_source": "acme/vpc/aws"
+				}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	mv, err := c.GetModuleVersion(context.Background(), "acme", "vpc", "aws", "1.1.0")
+	if err != nil {
+		t.Fatalf("GetModuleVersion: %v", err)
+	}
+	if mv.Version != "1.1.0" {
+		t.Errorf("Version = %q, want %q", mv.Version, "1.1.0")
+	}
+	if !mv.Deprecated {
+		t.Errorf("Deprecated = false, want true")
+	}
+	if mv.DeprecationMessage == nil || *mv.DeprecationMessage != "use 1.2.0" {
+		t.Errorf("DeprecationMessage = %v", mv.DeprecationMessage)
+	}
+	if mv.DeprecatedAt == nil || *mv.DeprecatedAt != "2026-05-01T00:00:00Z" {
+		t.Errorf("DeprecatedAt = %v", mv.DeprecatedAt)
+	}
+	if mv.ReplacementSource == nil || *mv.ReplacementSource != "acme/vpc/aws" {
+		t.Errorf("ReplacementSource = %v", mv.ReplacementSource)
+	}
+}
+
+// TestGetModuleVersion_VersionNotInListReturnsNotFound verifies that when the
+// module exists but the requested version is not in its `versions[]` list,
+// a 404-style APIError is returned so IsNotFound recognises it.
+func TestGetModuleVersion_VersionNotInListReturnsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "11111111-1111-1111-1111-111111111111",
+			"namespace": "acme",
+			"name": "vpc",
+			"system": "aws",
+			"versions": [
+				{ "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "version": "1.0.0", "deprecated": false }
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	mv, err := c.GetModuleVersion(context.Background(), "acme", "vpc", "aws", "9.9.9")
+	if err == nil {
+		t.Fatalf("GetModuleVersion: expected error, got nil (mv=%+v)", mv)
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound(err) = false, want true (err=%v)", err)
+	}
+	if mv != nil {
+		t.Errorf("mv = %+v, want nil", mv)
+	}
+}
+
+// TestGetModuleVersion_ModuleNotFoundPropagates verifies that when the
+// underlying module-detail GET returns 404, the same not-found error is
+// propagated to the caller (so resource Read can RemoveResource correctly).
+func TestGetModuleVersion_ModuleNotFoundPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error": "Module not found"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	mv, err := c.GetModuleVersion(context.Background(), "missing", "mod", "aws", "1.0.0")
+	if err == nil {
+		t.Fatalf("GetModuleVersion: expected error, got nil (mv=%+v)", mv)
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound(err) = false, want true (err=%v)", err)
+	}
+	if mv != nil {
+		t.Errorf("mv = %+v, want nil", mv)
+	}
+}


### PR DESCRIPTION
Closes #74

## Summary

`GetModuleVersion` was calling `GET /api/v1/modules/{ns}/{name}/{sys}/{version}` —
a route the backend has never exposed. The bare path returned 404, which
`client.IsNotFound` swallowed in `resource_module_version_deprecation.go`
Read (lines 136-146), dropping the resource from state and triggering
recreation on the next plan. Latent silent churn bug.

This change derives the version-level state from the module-detail
endpoint `GET /api/v1/modules/{ns}/{name}/{sys}` — an existing,
documented route that returns the full `versions[]` list. The frontend
already uses this approach in `useModuleDetail.ts`. Works against every
backend version shipped to date; no backend change required.

## Behaviour

- Module found, version present in `versions[]`: returns a populated
  `*ModuleVersion` (Version, Deprecated, DeprecationMessage, DeprecatedAt,
  ReplacementSource where supplied).
- Module found, version not present: returns a synthetic `*APIError` with
  status 404 so `IsNotFound` recognises it.
- Module not found: the 404 from `GetModule` propagates unchanged.

## Tests

New `internal/client/module_deprecations_test.go` with `httptest.NewServer`
covers all three branches: version-found-with-deprecation,
version-not-in-list, module-not-found.

## Changelog

- fix: `registry_module_version_deprecation` no longer silently drops itself
  from Terraform state on every refresh. The underlying `GetModuleVersion`
  client call was hitting a path the backend never exposed; it now derives
  the version's deprecation state from the existing module-detail endpoint
  (#74)