### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.2] - 2026-05-06
+
+### Fixed
+
+- `registry_module_version_deprecation` no longer churns state on every refresh.
+  `client.GetModuleVersion` was hitting `GET /api/v1/modules/{ns}/{name}/{sys}/{version}`
+  — a route the backend does not expose — so the Read implementation always
+  saw a 404, removed the resource from state, and triggered recreation on the
+  next plan. The client now derives version-level state from the existing
+  `GET /api/v1/modules/{ns}/{name}/{sys}` endpoint, the same approach the
+  frontend uses. Works against any backend version (#74, #75)
+
+### Changed
+
+- Bumped `GNUmakefile` `VERSION` to `0.3.2` so `make install` drops the
+  binary into a path matching the published release.
+
+---
+
 ## [0.3.1] - 2026-05-06
 
 ### Documentation

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ HOSTNAME     = registry.terraform.io
 NAMESPACE    = terraform-registry
 NAME         = registry
 BINARY       = terraform-provider-${NAME}
-VERSION      = 0.3.1
+VERSION      = 0.3.2
 OS_ARCH      = $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build


### PR DESCRIPTION
Release v0.3.2 — see CHANGELOG.md for details.

Patch release with one fix:
- `registry_module_version_deprecation` no longer silently churns state on every refresh (#74, #75)