### PR TITLE
chore(client): migrate User to spec.User, drop stale oidc_sub

### DIFF
--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -132,16 +132,6 @@ type OIDCGroupMapping struct {
 	RoleTemplateID string `json:"role_template_id"`
 }
 
-// User represents a registry user.
-type User struct {
-	ID        string  `json:"id"`
-	Email     string  `json:"email"`
-	Name      string  `json:"name"`
-	OIDCSub   *string `json:"oidc_sub,omitempty"`
-	CreatedAt string  `json:"created_at"`
-	UpdatedAt string  `json:"updated_at"`
-}
-
 // CreateUserRequest is the payload for creating a user.
 type CreateUserRequest struct {
 	Email   string  `json:"email"`
@@ -151,9 +141,8 @@ type CreateUserRequest struct {
 
 // UpdateUserRequest is the payload for updating a user.
 type UpdateUserRequest struct {
-	Email   string  `json:"email"`
-	Name    string  `json:"name"`
-	OIDCSub *string `json:"oidc_sub,omitempty"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
 
 // Organization represents a registry organization.

--- a/internal/client/users.go
+++ b/internal/client/users.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/terraform-registry/terraform-provider-registry/internal/client/spec"
 )
 
-func (c *Client) CreateUser(ctx context.Context, req CreateUserRequest) (*User, error) {
+func (c *Client) CreateUser(ctx context.Context, req CreateUserRequest) (*spec.User, error) {
 	var resp struct {
-		User User `json:"user"`
+		User spec.User `json:"user"`
 	}
 	if err := c.Post(ctx, "/api/v1/users", req, &resp); err != nil {
 		return nil, err
@@ -16,9 +18,9 @@ func (c *Client) CreateUser(ctx context.Context, req CreateUserRequest) (*User, 
 	return &resp.User, nil
 }
 
-func (c *Client) GetUser(ctx context.Context, id string) (*User, error) {
+func (c *Client) GetUser(ctx context.Context, id string) (*spec.User, error) {
 	var resp struct {
-		User User `json:"user"`
+		User spec.User `json:"user"`
 	}
 	if err := c.Get(ctx, "/api/v1/users/"+id, &resp); err != nil {
 		return nil, err
@@ -26,9 +28,9 @@ func (c *Client) GetUser(ctx context.Context, id string) (*User, error) {
 	return &resp.User, nil
 }
 
-func (c *Client) UpdateUser(ctx context.Context, id string, req UpdateUserRequest) (*User, error) {
+func (c *Client) UpdateUser(ctx context.Context, id string, req UpdateUserRequest) (*spec.User, error) {
 	var resp struct {
-		User User `json:"user"`
+		User spec.User `json:"user"`
 	}
 	if err := c.Put(ctx, "/api/v1/users/"+id, req, &resp); err != nil {
 		return nil, err
@@ -40,7 +42,7 @@ func (c *Client) DeleteUser(ctx context.Context, id string) error {
 	return c.Delete(ctx, "/api/v1/users/"+id)
 }
 
-func (c *Client) ListUsers(ctx context.Context, search string) ([]User, error) {
+func (c *Client) ListUsers(ctx context.Context, search string) ([]spec.User, error) {
 	path := "/api/v1/users"
 	if search != "" {
 		path += BuildQuery(map[string]string{"q": search})
@@ -51,9 +53,9 @@ func (c *Client) ListUsers(ctx context.Context, search string) ([]User, error) {
 		return nil, err
 	}
 
-	users := make([]User, 0, len(items))
+	users := make([]spec.User, 0, len(items))
 	for _, raw := range items {
-		var u User
+		var u spec.User
 		if err := json.Unmarshal(raw, &u); err != nil {
 			return nil, fmt.Errorf("unmarshaling user: %w", err)
 		}

--- a/internal/provider/datasource_users.go
+++ b/internal/provider/datasource_users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+	"github.com/terraform-registry/terraform-provider-registry/internal/client/spec"
 )
 
 var _ datasource.DataSource = &UsersDataSource{}
@@ -25,7 +26,6 @@ type UserModel struct {
 	ID        types.String `tfsdk:"id"`
 	Email     types.String `tfsdk:"email"`
 	Name      types.String `tfsdk:"name"`
-	OIDCSub   types.String `tfsdk:"oidc_sub"`
 	CreatedAt types.String `tfsdk:"created_at"`
 	UpdatedAt types.String `tfsdk:"updated_at"`
 }
@@ -54,7 +54,6 @@ func (d *UsersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 						"id":         schema.StringAttribute{Computed: true, Description: "UUID of the user."},
 						"email":      schema.StringAttribute{Computed: true, Description: "User email."},
 						"name":       schema.StringAttribute{Computed: true, Description: "User display name."},
-						"oidc_sub":   schema.StringAttribute{Computed: true, Description: "OIDC subject identifier."},
 						"created_at": schema.StringAttribute{Computed: true, Description: "Creation timestamp."},
 						"updated_at": schema.StringAttribute{Computed: true, Description: "Last update timestamp."},
 					},
@@ -89,23 +88,26 @@ func (d *UsersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	models := make([]UserModel, len(users))
+	config.Users = make([]UserModel, len(users))
 	for i, u := range users {
-		m := UserModel{
-			ID:        types.StringValue(u.ID),
-			Email:     types.StringValue(u.Email),
-			Name:      types.StringValue(u.Name),
-			CreatedAt: types.StringValue(u.CreatedAt),
-			UpdatedAt: types.StringValue(u.UpdatedAt),
-		}
-		if u.OIDCSub != nil {
-			m.OIDCSub = types.StringValue(*u.OIDCSub)
-		} else {
-			m.OIDCSub = types.StringNull()
-		}
-		models[i] = m
+		config.Users[i] = specUserToModel(&u)
 	}
 
-	config.Users = models
 	resp.Diagnostics.Append(resp.State.Set(ctx, config)...)
+}
+
+func specUserToModel(u *spec.User) UserModel {
+	deref := func(s *string) types.String {
+		if s == nil {
+			return types.StringValue("")
+		}
+		return types.StringValue(*s)
+	}
+	return UserModel{
+		ID:        deref(u.Id),
+		Email:     deref(u.Email),
+		Name:      deref(u.Name),
+		CreatedAt: deref(u.CreatedAt),
+		UpdatedAt: deref(u.UpdatedAt),
+	}
 }

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/terraform-registry/terraform-provider-registry/internal/client"
+	"github.com/terraform-registry/terraform-provider-registry/internal/client/spec"
 )
 
 var _ resource.Resource = &UserResource{}
@@ -23,7 +24,6 @@ type UserResourceModel struct {
 	ID        types.String `tfsdk:"id"`
 	Email     types.String `tfsdk:"email"`
 	Name      types.String `tfsdk:"name"`
-	OIDCSub   types.String `tfsdk:"oidc_sub"`
 	CreatedAt types.String `tfsdk:"created_at"`
 	UpdatedAt types.String `tfsdk:"updated_at"`
 }
@@ -54,11 +54,6 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"name": schema.StringAttribute{
 				Description: "Display name of the user.",
 				Required:    true,
-			},
-			"oidc_sub": schema.StringAttribute{
-				Description: "OIDC subject identifier. Set to link this user to an external identity provider subject.",
-				Optional:    true,
-				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
 				Description: "ISO 8601 timestamp when the user was created.",
@@ -94,16 +89,10 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	createReq := client.CreateUserRequest{
+	user, err := r.client.CreateUser(ctx, client.CreateUserRequest{
 		Email: plan.Email.ValueString(),
 		Name:  plan.Name.ValueString(),
-	}
-	if !plan.OIDCSub.IsNull() && !plan.OIDCSub.IsUnknown() {
-		v := plan.OIDCSub.ValueString()
-		createReq.OIDCSub = &v
-	}
-
-	user, err := r.client.CreateUser(ctx, createReq)
+	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error Creating User", err.Error())
 		return
@@ -139,16 +128,10 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	updateReq := client.UpdateUserRequest{
+	user, err := r.client.UpdateUser(ctx, plan.ID.ValueString(), client.UpdateUserRequest{
 		Email: plan.Email.ValueString(),
 		Name:  plan.Name.ValueString(),
-	}
-	if !plan.OIDCSub.IsNull() && !plan.OIDCSub.IsUnknown() {
-		v := plan.OIDCSub.ValueString()
-		updateReq.OIDCSub = &v
-	}
-
-	user, err := r.client.UpdateUser(ctx, plan.ID.ValueString(), updateReq)
+	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating User", err.Error())
 		return
@@ -178,18 +161,18 @@ func (r *UserResource) ImportState(ctx context.Context, req resource.ImportState
 	resp.Diagnostics.Append(resp.State.Set(ctx, userToModel(user))...)
 }
 
-func userToModel(u *client.User) UserResourceModel {
-	m := UserResourceModel{
-		ID:        types.StringValue(u.ID),
-		Email:     types.StringValue(u.Email),
-		Name:      types.StringValue(u.Name),
-		CreatedAt: types.StringValue(u.CreatedAt),
-		UpdatedAt: types.StringValue(u.UpdatedAt),
+func userToModel(u *spec.User) UserResourceModel {
+	deref := func(s *string) types.String {
+		if s == nil {
+			return types.StringValue("")
+		}
+		return types.StringValue(*s)
 	}
-	if u.OIDCSub != nil {
-		m.OIDCSub = types.StringValue(*u.OIDCSub)
-	} else {
-		m.OIDCSub = types.StringNull()
+	return UserResourceModel{
+		ID:        deref(u.Id),
+		Email:     deref(u.Email),
+		Name:      deref(u.Name),
+		CreatedAt: deref(u.CreatedAt),
+		UpdatedAt: deref(u.UpdatedAt),
 	}
-	return m
 }


### PR DESCRIPTION
Closes #79
Part of #34

Switches `internal/client/users.go` to return `spec.User` (generated from the pinned backend's OpenAPI spec at tag 1.1.6) instead of the hand-written `User` struct. First resource migration in the oapi-codegen pipeline.

## What changed

- **`internal/client/models.go`**: removed hand-written `User` struct; removed `OIDCSub *string` from `UpdateUserRequest` (backend's `admin.UpdateUserRequest` schema has no `oidc_sub` field)
- **`internal/client/users.go`**: all `*User` return types → `*spec.User`; `[]User` → `[]spec.User`
- **`internal/provider/resource_user.go`**: updated `userToModel` to dereference `*string` pointer fields (`spec.User` uses all-pointer fields); removed `oidc_sub` from schema and `UserResourceModel`
- **`internal/provider/datasource_users.go`**: same — removed `oidc_sub` from `UserModel` and nested schema; updated `specUserToModel` helper

## Why remove `oidc_sub`

The backend's `User` response schema has never included `oidc_sub` (confirmed via the committed `openapi3.json`). The attribute was `Optional+Computed` in Terraform state but always came back null after create/refresh — a silent state-drift bug. Removing it makes the schema honest. The `oidc_sub` field remains in `CreateUserRequest` since `admin.CreateUserRequest` does accept it.

## Changelog
- chore(client): migrate User response struct to generated spec.User; remove non-functional oidc_sub attribute from registry_user resource and registry_users data source