### PR TITLE
fix: align identity models with backend post-extraction

### DIFF
--- a/internal/client/apikeys.go
+++ b/internal/client/apikeys.go
@@ -38,10 +38,10 @@ func (c *Client) DeleteAPIKey(ctx context.Context, id string) error {
 	return c.Delete(ctx, "/api/v1/apikeys/"+id)
 }
 
-func (c *Client) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
+func (c *Client) ListAPIKeys(ctx context.Context, organizationID string) ([]APIKey, error) {
 	path := "/api/v1/apikeys"
-	if userID != "" {
-		path += BuildQuery(map[string]string{"user_id": userID})
+	if organizationID != "" {
+		path += BuildQuery(map[string]string{"organization_id": organizationID})
 	}
 
 	items, err := FetchAllPages(ctx, c, path, "keys")
@@ -58,4 +58,14 @@ func (c *Client) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, erro
 		keys = append(keys, k)
 	}
 	return keys, nil
+}
+
+// RotateAPIKey rotates an API key via POST /api/v1/apikeys/:id/rotate.
+// Returns the new key (raw key value is only available in this response).
+func (c *Client) RotateAPIKey(ctx context.Context, id string) (*CreateAPIKeyResponse, error) {
+	var resp CreateAPIKeyResponse
+	if err := c.Post(ctx, "/api/v1/apikeys/"+id+"/rotate", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -116,20 +116,40 @@ type MTLSConfig struct {
 	ServerCert *string `json:"server_cert_subject,omitempty"`
 }
 
-// OIDCConfig represents the backend OIDC configuration (read-only).
+// OIDCConfig represents the backend OIDC configuration response (read-only).
+// Mirrors backend models.OIDCConfigResponse.
 type OIDCConfig struct {
-	Issuer        string   `json:"issuer"`
-	ClientID      string   `json:"client_id"`
-	Scopes        []string `json:"scopes"`
-	GroupsClaim   string   `json:"groups_claim"`
-	UsernameClaim string   `json:"username_claim"`
+	ID             string                 `json:"id"`
+	Name           string                 `json:"name"`
+	ProviderType   string                 `json:"provider_type"`
+	IssuerURL      string                 `json:"issuer_url"`
+	ClientID       string                 `json:"client_id"`
+	RedirectURL    string                 `json:"redirect_url"`
+	Scopes         []string               `json:"scopes"`
+	IsActive       bool                   `json:"is_active"`
+	GroupClaimName string                 `json:"group_claim_name,omitempty"`
+	GroupMappings  []OIDCGroupMapping     `json:"group_mappings,omitempty"`
+	DefaultRole    string                 `json:"default_role,omitempty"`
+	ExtraConfig    map[string]interface{} `json:"extra_config,omitempty"`
+	CreatedAt      string                 `json:"created_at"`
+	UpdatedAt      string                 `json:"updated_at"`
+	CreatedBy      *string                `json:"created_by,omitempty"`
+	UpdatedBy      *string                `json:"updated_by,omitempty"`
 }
 
 // OIDCGroupMapping represents a single OIDC group → role mapping entry.
+// Mirrors backend models.OIDCGroupMapping.
 type OIDCGroupMapping struct {
-	OIDCGroup      string `json:"oidc_group"`
-	OrganizationID string `json:"organization_id"`
-	RoleTemplateID string `json:"role_template_id"`
+	Group        string `json:"group"`
+	Organization string `json:"organization"`
+	Role         string `json:"role"`
+}
+
+// OIDCGroupMappingInput is the request body for PUT /api/v1/admin/oidc/group-mapping.
+type OIDCGroupMappingInput struct {
+	GroupClaimName string             `json:"group_claim_name"`
+	GroupMappings  []OIDCGroupMapping `json:"group_mappings"`
+	DefaultRole    string             `json:"default_role"`
 }
 
 // CreateUserRequest is the payload for creating a user.

--- a/internal/client/oidc.go
+++ b/internal/client/oidc.go
@@ -11,20 +11,21 @@ func (c *Client) GetOIDCConfig(ctx context.Context) (*OIDCConfig, error) {
 	return &cfg, nil
 }
 
-// GetOIDCGroupMappings fetches the current OIDC group mappings via GET /api/v1/admin/oidc/group-mapping.
+// GetOIDCGroupMappings returns the group mappings from the active OIDC config.
+// The backend has no separate GET for group mappings; they are embedded in the config response.
 func (c *Client) GetOIDCGroupMappings(ctx context.Context) ([]OIDCGroupMapping, error) {
-	var mappings []OIDCGroupMapping
-	if err := c.Get(ctx, "/api/v1/admin/oidc/group-mapping", &mappings); err != nil {
+	cfg, err := c.GetOIDCConfig(ctx)
+	if err != nil {
 		return nil, err
 	}
-	return mappings, nil
+	return cfg.GroupMappings, nil
 }
 
-// SetOIDCGroupMappings replaces the entire OIDC group mapping table via PUT /api/v1/admin/oidc/group-mapping.
-func (c *Client) SetOIDCGroupMappings(ctx context.Context, mappings []OIDCGroupMapping) ([]OIDCGroupMapping, error) {
-	var result []OIDCGroupMapping
-	if err := c.Put(ctx, "/api/v1/admin/oidc/group-mapping", mappings, &result); err != nil {
+// SetOIDCGroupMappings replaces the OIDC group mapping configuration via PUT /api/v1/admin/oidc/group-mapping.
+func (c *Client) SetOIDCGroupMappings(ctx context.Context, input OIDCGroupMappingInput) (*OIDCConfig, error) {
+	var result OIDCConfig
+	if err := c.Put(ctx, "/api/v1/admin/oidc/group-mapping", input, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return &result, nil
 }

--- a/internal/provider/datasource_apikeys.go
+++ b/internal/provider/datasource_apikeys.go
@@ -17,8 +17,8 @@ type APIKeysDataSource struct {
 }
 
 type APIKeysDataSourceModel struct {
-	UserID  types.String   `tfsdk:"user_id"`
-	APIKeys []APIKeyDSItem `tfsdk:"api_keys"`
+	OrganizationID types.String   `tfsdk:"organization_id"`
+	APIKeys        []APIKeyDSItem `tfsdk:"api_keys"`
 }
 
 type APIKeyDSItem struct {
@@ -43,10 +43,10 @@ func (d *APIKeysDataSource) Metadata(_ context.Context, req datasource.MetadataR
 
 func (d *APIKeysDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Lists API keys, optionally filtered by user.",
+		Description: "Lists API keys, optionally filtered by organization.",
 		Attributes: map[string]schema.Attribute{
-			"user_id": schema.StringAttribute{
-				Description: "Filter by user UUID.",
+			"organization_id": schema.StringAttribute{
+				Description: "Filter by organization UUID.",
 				Optional:    true,
 			},
 			"api_keys": schema.ListNestedAttribute{
@@ -93,7 +93,7 @@ func (d *APIKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	keys, err := d.client.ListAPIKeys(ctx, config.UserID.ValueString())
+	keys, err := d.client.ListAPIKeys(ctx, config.OrganizationID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error Listing API Keys", err.Error())
 		return

--- a/internal/provider/datasource_oidc_config.go
+++ b/internal/provider/datasource_oidc_config.go
@@ -17,11 +17,18 @@ type OIDCConfigDataSource struct {
 }
 
 type OIDCConfigDataSourceModel struct {
-	Issuer        types.String `tfsdk:"issuer"`
-	ClientID      types.String `tfsdk:"client_id"`
-	Scopes        types.List   `tfsdk:"scopes"`
-	GroupsClaim   types.String `tfsdk:"groups_claim"`
-	UsernameClaim types.String `tfsdk:"username_claim"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ProviderType   types.String `tfsdk:"provider_type"`
+	IssuerURL      types.String `tfsdk:"issuer_url"`
+	ClientID       types.String `tfsdk:"client_id"`
+	RedirectURL    types.String `tfsdk:"redirect_url"`
+	Scopes         types.List   `tfsdk:"scopes"`
+	IsActive       types.Bool   `tfsdk:"is_active"`
+	GroupClaimName types.String `tfsdk:"group_claim_name"`
+	DefaultRole    types.String `tfsdk:"default_role"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	UpdatedAt      types.String `tfsdk:"updated_at"`
 }
 
 func NewOIDCConfigDataSource() datasource.DataSource {
@@ -36,7 +43,19 @@ func (d *OIDCConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 	resp.Schema = schema.Schema{
 		Description: "Reads the backend OIDC configuration (read-only). The client secret is never exposed.",
 		Attributes: map[string]schema.Attribute{
-			"issuer": schema.StringAttribute{
+			"id": schema.StringAttribute{
+				Description: "UUID of the OIDC configuration.",
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Display name of the OIDC configuration.",
+				Computed:    true,
+			},
+			"provider_type": schema.StringAttribute{
+				Description: "OIDC provider type (e.g. generic, okta, azure-ad).",
+				Computed:    true,
+			},
+			"issuer_url": schema.StringAttribute{
 				Description: "OIDC issuer URL.",
 				Computed:    true,
 			},
@@ -44,17 +63,33 @@ func (d *OIDCConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Description: "OIDC client ID.",
 				Computed:    true,
 			},
+			"redirect_url": schema.StringAttribute{
+				Description: "OAuth2 redirect URL.",
+				Computed:    true,
+			},
 			"scopes": schema.ListAttribute{
 				Description: "Requested OIDC scopes.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},
-			"groups_claim": schema.StringAttribute{
-				Description: "JWT claim used to extract group membership.",
+			"is_active": schema.BoolAttribute{
+				Description: "Whether this OIDC configuration is active.",
 				Computed:    true,
 			},
-			"username_claim": schema.StringAttribute{
-				Description: "JWT claim used as the username.",
+			"group_claim_name": schema.StringAttribute{
+				Description: "JWT claim name used to extract group membership.",
+				Computed:    true,
+			},
+			"default_role": schema.StringAttribute{
+				Description: "Default role assigned when no group mapping matches.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Creation timestamp (RFC3339).",
+				Computed:    true,
+			},
+			"updated_at": schema.StringAttribute{
+				Description: "Last update timestamp (RFC3339).",
 				Computed:    true,
 			},
 		},
@@ -87,11 +122,18 @@ func (d *OIDCConfigDataSource) Read(ctx context.Context, _ datasource.ReadReques
 	}
 
 	model := OIDCConfigDataSourceModel{
-		Issuer:        types.StringValue(cfg.Issuer),
-		ClientID:      types.StringValue(cfg.ClientID),
-		Scopes:        scopes,
-		GroupsClaim:   types.StringValue(cfg.GroupsClaim),
-		UsernameClaim: types.StringValue(cfg.UsernameClaim),
+		ID:             types.StringValue(cfg.ID),
+		Name:           types.StringValue(cfg.Name),
+		ProviderType:   types.StringValue(cfg.ProviderType),
+		IssuerURL:      types.StringValue(cfg.IssuerURL),
+		ClientID:       types.StringValue(cfg.ClientID),
+		RedirectURL:    types.StringValue(cfg.RedirectURL),
+		Scopes:         scopes,
+		IsActive:       types.BoolValue(cfg.IsActive),
+		GroupClaimName: types.StringValue(cfg.GroupClaimName),
+		DefaultRole:    types.StringValue(cfg.DefaultRole),
+		CreatedAt:      types.StringValue(cfg.CreatedAt),
+		UpdatedAt:      types.StringValue(cfg.UpdatedAt),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
 }

--- a/internal/provider/resource_oidc_group_mapping.go
+++ b/internal/provider/resource_oidc_group_mapping.go
@@ -20,10 +20,10 @@ type OIDCGroupMappingResource struct {
 }
 
 type OIDCGroupMappingResourceModel struct {
-	ID             types.String `tfsdk:"id"`
-	OIDCGroup      types.String `tfsdk:"oidc_group"`
-	OrganizationID types.String `tfsdk:"organization_id"`
-	RoleTemplateID types.String `tfsdk:"role_template_id"`
+	ID           types.String `tfsdk:"id"`
+	Group        types.String `tfsdk:"group"`
+	Organization types.String `tfsdk:"organization"`
+	Role         types.String `tfsdk:"role"`
 }
 
 func NewOIDCGroupMappingResource() resource.Resource {
@@ -39,28 +39,28 @@ func (r *OIDCGroupMappingResource) Schema(_ context.Context, _ resource.SchemaRe
 		Description: "Manages a single OIDC group → organization role mapping. The backend stores mappings as a full-replace list; this resource reads the current list, adds or removes its entry, and writes the list back.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "Composite identifier: {oidc_group}:{organization_id}.",
+				Description: "Composite identifier: {group}:{organization}.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"oidc_group": schema.StringAttribute{
+			"group": schema.StringAttribute{
 				Description: "OIDC groups claim value to match.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"organization_id": schema.StringAttribute{
-				Description: "UUID of the organization this mapping applies to.",
+			"organization": schema.StringAttribute{
+				Description: "Organization name or ID this mapping applies to.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"role_template_id": schema.StringAttribute{
-				Description: "UUID of the role template to assign.",
+			"role": schema.StringAttribute{
+				Description: "Role name to assign members of this group.",
 				Required:    true,
 			},
 		},
@@ -86,25 +86,30 @@ func (r *OIDCGroupMappingResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	current, err := r.client.GetOIDCGroupMappings(ctx)
+	cfg, err := r.client.GetOIDCConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		resp.Diagnostics.AddError("Error Reading OIDC Config", err.Error())
 		return
 	}
 
 	entry := client.OIDCGroupMapping{
-		OIDCGroup:      plan.OIDCGroup.ValueString(),
-		OrganizationID: plan.OrganizationID.ValueString(),
-		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+		Group:        plan.Group.ValueString(),
+		Organization: plan.Organization.ValueString(),
+		Role:         plan.Role.ValueString(),
 	}
 
-	updated := upsertMapping(current, entry)
-	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+	mappings := upsertMapping(cfg.GroupMappings, entry)
+	input := client.OIDCGroupMappingInput{
+		GroupClaimName: cfg.GroupClaimName,
+		GroupMappings:  mappings,
+		DefaultRole:    cfg.DefaultRole,
+	}
+	if _, err := r.client.SetOIDCGroupMappings(ctx, input); err != nil {
 		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
 		return
 	}
 
-	plan.ID = types.StringValue(oidcMappingID(plan.OIDCGroup.ValueString(), plan.OrganizationID.ValueString()))
+	plan.ID = types.StringValue(oidcMappingID(plan.Group.ValueString(), plan.Organization.ValueString()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -122,8 +127,8 @@ func (r *OIDCGroupMappingResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	for _, m := range mappings {
-		if m.OIDCGroup == state.OIDCGroup.ValueString() && m.OrganizationID == state.OrganizationID.ValueString() {
-			state.RoleTemplateID = types.StringValue(m.RoleTemplateID)
+		if m.Group == state.Group.ValueString() && m.Organization == state.Organization.ValueString() {
+			state.Role = types.StringValue(m.Role)
 			resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 			return
 		}
@@ -139,24 +144,30 @@ func (r *OIDCGroupMappingResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	current, err := r.client.GetOIDCGroupMappings(ctx)
+	cfg, err := r.client.GetOIDCConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		resp.Diagnostics.AddError("Error Reading OIDC Config", err.Error())
 		return
 	}
 
 	entry := client.OIDCGroupMapping{
-		OIDCGroup:      plan.OIDCGroup.ValueString(),
-		OrganizationID: plan.OrganizationID.ValueString(),
-		RoleTemplateID: plan.RoleTemplateID.ValueString(),
+		Group:        plan.Group.ValueString(),
+		Organization: plan.Organization.ValueString(),
+		Role:         plan.Role.ValueString(),
 	}
 
-	updated := upsertMapping(current, entry)
-	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+	mappings := upsertMapping(cfg.GroupMappings, entry)
+	input := client.OIDCGroupMappingInput{
+		GroupClaimName: cfg.GroupClaimName,
+		GroupMappings:  mappings,
+		DefaultRole:    cfg.DefaultRole,
+	}
+	if _, err := r.client.SetOIDCGroupMappings(ctx, input); err != nil {
 		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
 		return
 	}
 
+	plan.ID = types.StringValue(oidcMappingID(plan.Group.ValueString(), plan.Organization.ValueString()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -167,25 +178,30 @@ func (r *OIDCGroupMappingResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	current, err := r.client.GetOIDCGroupMappings(ctx)
+	cfg, err := r.client.GetOIDCConfig(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("Error Reading OIDC Group Mappings", err.Error())
+		resp.Diagnostics.AddError("Error Reading OIDC Config", err.Error())
 		return
 	}
 
-	updated := removeMapping(current, state.OIDCGroup.ValueString(), state.OrganizationID.ValueString())
-	if _, err := r.client.SetOIDCGroupMappings(ctx, updated); err != nil {
+	mappings := removeMapping(cfg.GroupMappings, state.Group.ValueString(), state.Organization.ValueString())
+	input := client.OIDCGroupMappingInput{
+		GroupClaimName: cfg.GroupClaimName,
+		GroupMappings:  mappings,
+		DefaultRole:    cfg.DefaultRole,
+	}
+	if _, err := r.client.SetOIDCGroupMappings(ctx, input); err != nil {
 		resp.Diagnostics.AddError("Error Setting OIDC Group Mappings", err.Error())
 	}
 }
 
-func oidcMappingID(group, orgID string) string {
-	return fmt.Sprintf("%s:%s", group, orgID)
+func oidcMappingID(group, org string) string {
+	return fmt.Sprintf("%s:%s", group, org)
 }
 
 func upsertMapping(current []client.OIDCGroupMapping, entry client.OIDCGroupMapping) []client.OIDCGroupMapping {
 	for i, m := range current {
-		if m.OIDCGroup == entry.OIDCGroup && m.OrganizationID == entry.OrganizationID {
+		if m.Group == entry.Group && m.Organization == entry.Organization {
 			current[i] = entry
 			return current
 		}
@@ -193,10 +209,10 @@ func upsertMapping(current []client.OIDCGroupMapping, entry client.OIDCGroupMapp
 	return append(current, entry)
 }
 
-func removeMapping(current []client.OIDCGroupMapping, group, orgID string) []client.OIDCGroupMapping {
+func removeMapping(current []client.OIDCGroupMapping, group, org string) []client.OIDCGroupMapping {
 	result := make([]client.OIDCGroupMapping, 0, len(current))
 	for _, m := range current {
-		if m.OIDCGroup != group || m.OrganizationID != orgID {
+		if m.Group != group || m.Organization != org {
 			result = append(result, m)
 		}
 	}


### PR DESCRIPTION
Closes #84, #85, #86, #87, #88

Aligns the provider's identity-related client models and Terraform schemas with the
backend's post-identity-extraction API shape.

## Changes
- **OIDCConfig model**: Rewritten to match `OIDCConfigResponse` (18 fields including id, name, provider_type, issuer_url, group_claim_name, etc.)
- **OIDCGroupMapping model**: Field names corrected from `oidc_group/organization_id/role_template_id` → `group/organization/role`
- **SetOIDCGroupMappings**: Now accepts `OIDCGroupMappingInput` (preserves group_claim_name + default_role on writes)
- **GetOIDCGroupMappings**: Reads from config response (backend has no separate GET endpoint)
- **ListAPIKeys**: Uses `organization_id` query param instead of `user_id`
- **RotateAPIKey**: New method for `POST /apikeys/:id/rotate`
- **datasource_oidc_config**: Full schema expansion to match OIDCConfigResponse
- **resource_oidc_group_mapping**: Attributes renamed to `group`/`organization`/`role`
- **datasource_apikeys**: Filter attribute renamed from `user_id` to `organization_id`

## Changelog
- fix: OIDCConfig model rewritten to match backend OIDCConfigResponse shape
- fix: OIDCGroupMapping fields corrected to group/organization/role
- fix: ListAPIKeys uses organization_id filter (was user_id)
- feat: add RotateAPIKey client method (POST /apikeys/:id/rotate)
- fix: OIDC data source schema expanded to full response fields
- fix: OIDC group mapping resource uses correct field names
- fix: API keys data source filter changed from user_id to organization_id